### PR TITLE
Delete expired manifests and data files when removing snapshots.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/com/netflix/iceberg/ExpireSnapshots.java
@@ -17,6 +17,7 @@
 package com.netflix.iceberg;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * API for removing old {@link Snapshot snapshots} from a table.
@@ -27,6 +28,10 @@ import java.util.List;
  * When committing, these changes will be applied to the latest table metadata. Commit conflicts
  * will be resolved by applying the changes to the new latest metadata and reattempting the commit.
  * <p>
+ * Manifest files that are no longer used by valid snapshots will be deleted. Data files that were
+ * deleted by snapshots that are expired will be deleted. {@link #deleteWith(Consumer)} can be used
+ * to pass an alternative deletion method.
+ *
  * {@link #apply()} returns a list of the snapshots that will be removed.
  */
 public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
@@ -47,4 +52,16 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    */
   ExpireSnapshots expireOlderThan(long timestampMillis);
 
+  /**
+   * Passes an alternative delete implementation that will be used for manifests and data files.
+   * <p>
+   * Manifest files that are no longer used by valid snapshots will be deleted. Data files that were
+   * deleted by snapshots that are expired will be deleted.
+   * <p>
+   * If this method is not called, unnecessary manifests and data files will still be deleted.
+   *
+   * @param deleteFunc a function that will be called to delete manifests and data files
+   * @return this for method chaining
+   */
+  ExpireSnapshots deleteWith(Consumer<String> deleteFunc);
 }

--- a/core/src/main/java/com/netflix/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/com/netflix/iceberg/RemoveSnapshots.java
@@ -19,9 +19,14 @@ package com.netflix.iceberg;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.CommitFailedException;
+import com.netflix.iceberg.exceptions.RuntimeIOException;
 import com.netflix.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
@@ -33,10 +38,20 @@ import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 class RemoveSnapshots implements ExpireSnapshots {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoveSnapshots.class);
+
+  private final Consumer<String> defaultDelete = new Consumer<String>() {
+    @Override
+    public void accept(String file) {
+      ops.deleteFile(file);
+    }
+  };
+
   private final TableOperations ops;
   private final Set<Long> idsToRemove = Sets.newHashSet();
   private TableMetadata base;
   private Long expireOlderThan = null;
+  private Consumer<String> deleteFunc = defaultDelete;
 
   RemoveSnapshots(TableOperations ops) {
     this.ops = ops;
@@ -52,6 +67,12 @@ class RemoveSnapshots implements ExpireSnapshots {
   @Override
   public ExpireSnapshots expireOlderThan(long timestampMillis) {
     this.expireOlderThan = timestampMillis;
+    return this;
+  }
+
+  @Override
+  public ExpireSnapshots deleteWith(Consumer<String> deleteFunc) {
+    this.deleteFunc = deleteFunc;
     return this;
   }
 
@@ -87,5 +108,61 @@ class RemoveSnapshots implements ExpireSnapshots {
           TableMetadata updated = internalApply();
           ops.commit(base, updated);
         });
+
+    // clean up the expired snapshots:
+    // 1. Get a list of the snapshots that were removed
+    // 2. Delete any data files that were deleted by those snapshots and are not in the table
+    // 3. Delete any manifests that are no longer used by current snapshots
+
+    // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
+    // as much of the delete work as possible and avoid orphaned data or manifest files.
+
+    TableMetadata current = ops.refresh();
+    Set<Long> currentIds = Sets.newHashSet();
+    Set<String> currentManifests = Sets.newHashSet();
+    for (Snapshot snapshot : current.snapshots()) {
+      currentIds.add(snapshot.snapshotId());
+      currentManifests.addAll(snapshot.manifests());
+    }
+
+    List<String> manifestsToDelete = Lists.newArrayList();
+    List<CharSequence> filesToDelete = Lists.newArrayList();
+    for (Snapshot snapshot : base.snapshots()) {
+      long snapshotId = snapshot.snapshotId();
+      if (!currentIds.contains(snapshotId)) {
+        // the snapshot was removed, so prepare deletes
+        Tasks.foreach(snapshot.manifests())
+            .noRetry().suppressFailureWhenFinished()
+            .onFailure((item, exc) ->
+              LOG.warn("Failed to get deleted files: this may cause orphaned data files", exc)
+            ).run(manifest -> {
+              if (!currentManifests.contains(manifest)) {
+                manifestsToDelete.add(manifest);
+              }
+
+              // even if the manifest is still used, it may contain files that can be deleted
+              try (ManifestReader reader = ManifestReader.read(ops.newInputFile(manifest))) {
+                for (ManifestEntry entry : reader.deletedFiles()) {
+                  if (snapshotId == entry.snapshotId()) {
+                    // if the snapshot ID matches a DELETE entry, it was deleted by the snapshot
+                    filesToDelete.add(entry.file().path());
+                  }
+                }
+              } catch (IOException e) {
+                throw new RuntimeIOException(e, "Failed to read manifest: " + manifest);
+              }
+            });
+      }
+    }
+
+    Tasks.foreach(filesToDelete)
+        .noRetry().suppressFailureWhenFinished()
+        .onFailure((file, exc) -> LOG.warn("Delete failed for data file: " + file, exc))
+        .run(file -> deleteFunc.accept(file.toString()));
+
+    Tasks.foreach(manifestsToDelete)
+        .noRetry().suppressFailureWhenFinished()
+        .onFailure((manifest, exc) -> LOG.warn("Delete failed for manifest: " + manifest, exc))
+        .run(deleteFunc::accept);
   }
 }


### PR DESCRIPTION
This adds logic after an expire snapshots commit to delete stale manifest and data files. It also adds a delete function to the `ExpireSnapshots` API so that the caller can use alternative delete logic.

For each snapshot that is removed, any data files that were marked deleted in that snapshot will be deleted. Because manifests can be reused, a manifest is only deleted if it is not referenced by any of the snapshots that are not yet expired.

This could delete files that are deleted an a snapshot and added back in a later snapshot. This could be updated to check whether the file is referenced by the current snapshot, but this solution is expensive and probably not worth the check. Callers should not delete files and re-add them without changing the file name or expiring the snapshot where the file was removed.