### PR TITLE
Add strict metrics evaluation for safe deletes

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -29,11 +29,13 @@ import java.util.Map;
 /**
  * Evaluates an {@link Expression} on a {@link DataFile} to test whether rows in the file may match.
  * <p>
+ * This evaluation is inclusive: it returns true if a file may match and false if it cannot match.
+ * <p>
  * Files are passed to {@link #eval(DataFile)}, which returns true if the file may contain matching
  * rows and false if the file cannot contain matching rows. Files may be skipped if and only if the
  * return value of {@code eval} is false.
  */
-public class MetricsEvaluator {
+public class InclusiveMetricsEvaluator {
   private final Schema schema;
   private final StructType struct;
   private final Expression expr;
@@ -46,7 +48,7 @@ public class MetricsEvaluator {
     return visitors.get();
   }
 
-  public MetricsEvaluator(Schema schema, Expression unbound) {
+  public InclusiveMetricsEvaluator(Schema schema, Expression unbound) {
     this.schema = schema;
     this.struct = schema.asStruct();
     this.expr = Binder.bind(struct, unbound);

--- a/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iceberg.expressions;
+
+import com.google.common.base.Preconditions;
+import com.netflix.iceberg.DataFile;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
+import com.netflix.iceberg.types.Conversions;
+import com.netflix.iceberg.types.Types;
+import com.netflix.iceberg.types.Types.StructType;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Evaluates an {@link Expression} on a {@link DataFile} to test whether all rows in the file match.
+ * <p>
+ * This evaluation is strict: it returns true if all rows in a file must match the expression. For
+ * example, if a file's ts column has min X and max Y, this evaluator will return true for ts < Y+1
+ * but not for ts < Y-1.
+ * <p>
+ * Files are passed to {@link #eval(DataFile)}, which returns true if all rows in the file must
+ * contain matching rows and false if the file may contain rows that do not match.
+ */
+public class StrictMetricsEvaluator {
+  private final Schema schema;
+  private final StructType struct;
+  private final Expression expr;
+  private transient ThreadLocal<MetricsEvalVisitor> visitors = null;
+
+  private MetricsEvalVisitor visitor() {
+    if (visitors == null) {
+      this.visitors = ThreadLocal.withInitial(MetricsEvalVisitor::new);
+    }
+    return visitors.get();
+  }
+
+  public StrictMetricsEvaluator(Schema schema, Expression unbound) {
+    this.schema = schema;
+    this.struct = schema.asStruct();
+    this.expr = Binder.bind(struct, unbound);
+  }
+
+  /**
+   * Test whether the file may contain records that match the expression.
+   *
+   * @param file a data file
+   * @return false if the file cannot contain rows that match the expression, true otherwise.
+   */
+  public boolean eval(DataFile file) {
+    // TODO: detect the case where a column is missing from the file using file's max field id.
+    return visitor().eval(file);
+  }
+
+  private static final boolean ROWS_MUST_MATCH = true;
+  private static final boolean ROWS_MIGHT_NOT_MATCH = false;
+
+  private class MetricsEvalVisitor extends BoundExpressionVisitor<Boolean> {
+    private Map<Integer, Long> valueCounts = null;
+    private Map<Integer, Long> nullCounts = null;
+    private Map<Integer, ByteBuffer> lowerBounds = null;
+    private Map<Integer, ByteBuffer> upperBounds = null;
+
+    private boolean eval(DataFile file) {
+      if (file.recordCount() <= 0) {
+        return ROWS_MUST_MATCH;
+      }
+
+      this.valueCounts = file.valueCounts();
+      this.nullCounts = file.nullValueCounts();
+      this.lowerBounds = file.lowerBounds();
+      this.upperBounds = file.upperBounds();
+
+      return ExpressionVisitors.visit(expr, this);
+    }
+
+    @Override
+    public Boolean alwaysTrue() {
+      return ROWS_MUST_MATCH; // all rows match
+    }
+
+    @Override
+    public Boolean alwaysFalse() {
+      return ROWS_MIGHT_NOT_MATCH; // no rows match
+    }
+
+    @Override
+    public Boolean not(Boolean result) {
+      return !result;
+    }
+
+    @Override
+    public Boolean and(Boolean leftResult, Boolean rightResult) {
+      return leftResult && rightResult;
+    }
+
+    @Override
+    public Boolean or(Boolean leftResult, Boolean rightResult) {
+      return leftResult || rightResult;
+    }
+
+    @Override
+    public <T> Boolean isNull(BoundReference<T> ref) {
+      // no need to check whether the field is required because binding evaluates that case
+      // if the column has any non-null values, the expression does not match
+      Integer id = ref.fieldId();
+      Preconditions.checkNotNull(struct.field(id),
+          "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (valueCounts != null && valueCounts.containsKey(id) &&
+          nullCounts != null && nullCounts.containsKey(id) &&
+          valueCounts.get(id) - nullCounts.get(id) == 0) {
+        return ROWS_MUST_MATCH;
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notNull(BoundReference<T> ref) {
+      // no need to check whether the field is required because binding evaluates that case
+      // if the column has any null values, the expression does not match
+      Integer id = ref.fieldId();
+      Preconditions.checkNotNull(struct.field(id),
+          "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (nullCounts != null && nullCounts.containsKey(id) && nullCounts.get(id) == 0) {
+        return ROWS_MUST_MATCH;
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when: <----------Min----Max---X------->
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (upperBounds != null && upperBounds.containsKey(id)) {
+        T upper = Conversions.fromByteBuffer(field.type(), upperBounds.get(id));
+
+        int cmp = lit.comparator().compare(upper, lit.value());
+        if (cmp < 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when: <----------Min----Max---X------->
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (upperBounds != null && upperBounds.containsKey(id)) {
+        T upper = Conversions.fromByteBuffer(field.type(), upperBounds.get(id));
+
+        int cmp = lit.comparator().compare(upper, lit.value());
+        if (cmp <= 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when: <-------X---Min----Max---------->
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+        T lower = Conversions.fromByteBuffer(field.type(), lowerBounds.get(id));
+
+        int cmp = lit.comparator().compare(lower, lit.value());
+        if (cmp > 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when: <-------X---Min----Max---------->
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+        T lower = Conversions.fromByteBuffer(field.type(), lowerBounds.get(id));
+
+        int cmp = lit.comparator().compare(lower, lit.value());
+        if (cmp >= 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean eq(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when Min == X == Max
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+        T lower = Conversions.fromByteBuffer(struct.field(id).type(), lowerBounds.get(id));
+
+        int cmp = lit.comparator().compare(lower, lit.value());
+        if (cmp != 0) {
+          return ROWS_MIGHT_NOT_MATCH;
+        }
+      }
+
+      if (upperBounds != null && upperBounds.containsKey(id)) {
+        T upper = Conversions.fromByteBuffer(field.type(), upperBounds.get(id));
+
+        int cmp = lit.comparator().compare(upper, lit.value());
+        if (cmp != 0) {
+          return ROWS_MIGHT_NOT_MATCH;
+        }
+      }
+
+      return ROWS_MUST_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
+      // Rows must match when X < Min or Max < X because it is not in the range
+      Integer id = ref.fieldId();
+      Types.NestedField field = struct.field(id);
+      Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+        T lower = Conversions.fromByteBuffer(struct.field(id).type(), lowerBounds.get(id));
+
+        int cmp = lit.comparator().compare(lower, lit.value());
+        if (cmp > 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      if (upperBounds != null && upperBounds.containsKey(id)) {
+        T upper = Conversions.fromByteBuffer(field.type(), upperBounds.get(id));
+
+        int cmp = lit.comparator().compare(upper, lit.value());
+        if (cmp < 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean in(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notIn(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+  }
+}

--- a/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
@@ -228,25 +228,26 @@ public class StrictMetricsEvaluator {
       Types.NestedField field = struct.field(id);
       Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
 
-      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+      if (lowerBounds != null && lowerBounds.containsKey(id) &&
+          upperBounds != null && upperBounds.containsKey(id)) {
         T lower = Conversions.fromByteBuffer(struct.field(id).type(), lowerBounds.get(id));
 
         int cmp = lit.comparator().compare(lower, lit.value());
         if (cmp != 0) {
           return ROWS_MIGHT_NOT_MATCH;
         }
-      }
 
-      if (upperBounds != null && upperBounds.containsKey(id)) {
         T upper = Conversions.fromByteBuffer(field.type(), upperBounds.get(id));
 
-        int cmp = lit.comparator().compare(upper, lit.value());
+        cmp = lit.comparator().compare(upper, lit.value());
         if (cmp != 0) {
           return ROWS_MIGHT_NOT_MATCH;
         }
+
+        return ROWS_MUST_MATCH;
       }
 
-      return ROWS_MUST_MATCH;
+      return ROWS_MIGHT_NOT_MATCH;
     }
 
     @Override

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -47,7 +47,7 @@ import static com.netflix.iceberg.types.Types.NestedField.required;
 public class TestInclusiveMetricsEvaluator {
   private static final Schema SCHEMA = new Schema(
       required(1, "id", IntegerType.get()),
-      required(2, "cat", Types.StringType.get()), // categorical
+      optional(2, "no_stats", Types.IntegerType.get()),
       required(3, "required", Types.StringType.get()),
       optional(4, "all_nulls", Types.StringType.get()),
       optional(5, "some_nulls", Types.StringType.get()),
@@ -117,9 +117,9 @@ public class TestInclusiveMetricsEvaluator {
     DataFile missingStats = new TestDataFile("file.parquet", Row.of(), 50);
 
     Expression[] exprs = new Expression[] {
-        lessThan("id", 5), lessThanOrEqual("id", 30), equal("id", 70), greaterThan("id", 78),
-        greaterThanOrEqual("id", 90), notEqual("id", 101), isNull("some_nulls"),
-        notNull("some_nulls")
+        lessThan("no_stats", 5), lessThanOrEqual("no_stats", 30), equal("no_stats", 70),
+        greaterThan("no_stats", 78), greaterThanOrEqual("no_stats", 90), notEqual("no_stats", 101),
+        isNull("no_stats"), notNull("no_stats")
     };
 
     for (Expression expr : exprs) {
@@ -140,7 +140,7 @@ public class TestInclusiveMetricsEvaluator {
 
     for (Expression expr : exprs) {
       boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, expr).eval(empty);
-      Assert.assertFalse("Should read when missing stats for expr: " + expr, shouldRead);
+      Assert.assertFalse("Should never read 0-record file: " + expr, shouldRead);
     }
   }
 

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -44,7 +44,7 @@ import static com.netflix.iceberg.types.Conversions.toByteBuffer;
 import static com.netflix.iceberg.types.Types.NestedField.optional;
 import static com.netflix.iceberg.types.Types.NestedField.required;
 
-public class TestMetricsEvaluator {
+public class TestInclusiveMetricsEvaluator {
   private static final Schema SCHEMA = new Schema(
       required(1, "id", IntegerType.get()),
       required(2, "cat", Types.StringType.get()), // categorical
@@ -74,34 +74,34 @@ public class TestMetricsEvaluator {
 
   @Test
   public void testAllNulls() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
     Assert.assertFalse("Should skip: no non-null value in all null column", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notNull("some_nulls")).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notNull("some_nulls")).eval(FILE);
     Assert.assertTrue("Should read: column with some nulls contains a non-null value", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notNull("no_nulls")).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notNull("no_nulls")).eval(FILE);
     Assert.assertTrue("Should read: non-null column contains a non-null value", shouldRead);
   }
 
   @Test
   public void testNoNulls() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, isNull("all_nulls")).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, isNull("all_nulls")).eval(FILE);
     Assert.assertTrue("Should read: at least one null value in all null column", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, isNull("some_nulls")).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, isNull("some_nulls")).eval(FILE);
     Assert.assertTrue("Should read: column with some nulls contains a null value", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, isNull("no_nulls")).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, isNull("no_nulls")).eval(FILE);
     Assert.assertFalse("Should skip: non-null column contains no null values", shouldRead);
   }
 
   @Test
   public void testRequiredColumn() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, notNull("required")).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notNull("required")).eval(FILE);
     Assert.assertTrue("Should read: required columns are always non-null", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, isNull("required")).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, isNull("required")).eval(FILE);
     Assert.assertFalse("Should skip: required columns are always non-null", shouldRead);
   }
 
@@ -109,7 +109,7 @@ public class TestMetricsEvaluator {
   public void testMissingColumn() {
     TestHelpers.assertThrows("Should complain about missing column in expression",
         ValidationException.class, "Cannot find field 'missing'",
-        () -> new MetricsEvaluator(SCHEMA, lessThan("missing", 5)).eval(FILE));
+        () -> new InclusiveMetricsEvaluator(SCHEMA, lessThan("missing", 5)).eval(FILE));
   }
 
   @Test
@@ -123,7 +123,7 @@ public class TestMetricsEvaluator {
     };
 
     for (Expression expr : exprs) {
-      boolean shouldRead = new MetricsEvaluator(SCHEMA, expr).eval(missingStats);
+      boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, expr).eval(missingStats);
       Assert.assertTrue("Should read when missing stats for expr: " + expr, shouldRead);
     }
   }
@@ -139,7 +139,7 @@ public class TestMetricsEvaluator {
     };
 
     for (Expression expr : exprs) {
-      boolean shouldRead = new MetricsEvaluator(SCHEMA, expr).eval(empty);
+      boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, expr).eval(empty);
       Assert.assertFalse("Should read when missing stats for expr: " + expr, shouldRead);
     }
   }
@@ -147,21 +147,21 @@ public class TestMetricsEvaluator {
   @Test
   public void testNot() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, not(lessThan("id", 5))).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, not(lessThan("id", 5))).eval(FILE);
     Assert.assertTrue("Should read: not(false)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, not(greaterThan("id", 5))).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, not(greaterThan("id", 5))).eval(FILE);
     Assert.assertFalse("Should skip: not(true)", shouldRead);
   }
 
   @Test
   public void testAnd() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
-    boolean shouldRead = new MetricsEvaluator(SCHEMA,
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA,
         and(lessThan("id", 5), greaterThanOrEqual("id", 0))).eval(FILE);
     Assert.assertFalse("Should skip: and(false, false)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA,
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA,
         and(greaterThan("id", 5), lessThanOrEqual("id", 30))).eval(FILE);
     Assert.assertTrue("Should read: and(true, true)", shouldRead);
   }
@@ -169,120 +169,120 @@ public class TestMetricsEvaluator {
   @Test
   public void testOr() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
-    boolean shouldRead = new MetricsEvaluator(SCHEMA,
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA,
         or(lessThan("id", 5), greaterThanOrEqual("id", 80))).eval(FILE);
     Assert.assertFalse("Should skip: or(false, false)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA,
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA,
         or(lessThan("id", 5), greaterThanOrEqual("id", 60))).eval(FILE);
     Assert.assertTrue("Should read: or(false, true)", shouldRead);
   }
 
   @Test
   public void testIntegerLt() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, lessThan("id", 5)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThan("id", 5)).eval(FILE);
     Assert.assertFalse("Should not read: id range below lower bound (5 < 30)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThan("id", 30)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThan("id", 30)).eval(FILE);
     Assert.assertFalse("Should not read: id range below lower bound (30 is not < 30)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThan("id", 31)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThan("id", 31)).eval(FILE);
     Assert.assertTrue("Should read: one possible id", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThan("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThan("id", 79)).eval(FILE);
     Assert.assertTrue("Should read: may possible ids", shouldRead);
   }
 
   @Test
   public void testIntegerLtEq() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, lessThanOrEqual("id", 5)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 5)).eval(FILE);
     Assert.assertFalse("Should not read: id range below lower bound (5 < 30)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThanOrEqual("id", 29)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 29)).eval(FILE);
     Assert.assertFalse("Should not read: id range below lower bound (29 < 30)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThanOrEqual("id", 30)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 30)).eval(FILE);
     Assert.assertTrue("Should read: one possible id", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, lessThanOrEqual("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 79)).eval(FILE);
     Assert.assertTrue("Should read: many possible ids", shouldRead);
   }
 
   @Test
   public void testIntegerGt() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, greaterThan("id", 85)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThan("id", 85)).eval(FILE);
     Assert.assertFalse("Should not read: id range above upper bound (85 < 79)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThan("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThan("id", 79)).eval(FILE);
     Assert.assertFalse("Should not read: id range above upper bound (79 is not > 79)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThan("id", 78)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThan("id", 78)).eval(FILE);
     Assert.assertTrue("Should read: one possible id", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThan("id", 75)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThan("id", 75)).eval(FILE);
     Assert.assertTrue("Should read: may possible ids", shouldRead);
   }
 
   @Test
   public void testIntegerGtEq() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 85)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 85)).eval(FILE);
     Assert.assertFalse("Should not read: id range above upper bound (85 < 79)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 80)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 80)).eval(FILE);
     Assert.assertFalse("Should not read: id range above upper bound (80 > 79)", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 79)).eval(FILE);
     Assert.assertTrue("Should read: one possible id", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 75)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 75)).eval(FILE);
     Assert.assertTrue("Should read: may possible ids", shouldRead);
   }
 
   @Test
   public void testIntegerEq() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 5)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 5)).eval(FILE);
     Assert.assertFalse("Should not read: id below lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 29)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 29)).eval(FILE);
     Assert.assertFalse("Should not read: id below lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 30)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 30)).eval(FILE);
     Assert.assertTrue("Should read: id equal to lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 75)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 75)).eval(FILE);
     Assert.assertTrue("Should read: id between lower and upper bounds", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 79)).eval(FILE);
     Assert.assertTrue("Should read: id equal to upper bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 80)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 80)).eval(FILE);
     Assert.assertFalse("Should not read: id above upper bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, equal("id", 85)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, equal("id", 85)).eval(FILE);
     Assert.assertFalse("Should not read: id above upper bound", shouldRead);
   }
 
   @Test
   public void testIntegerNotEq() {
-    boolean shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 5)).eval(FILE);
+    boolean shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 5)).eval(FILE);
     Assert.assertTrue("Should read: id below lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 29)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 29)).eval(FILE);
     Assert.assertTrue("Should read: id below lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 30)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 30)).eval(FILE);
     Assert.assertTrue("Should read: id equal to lower bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 75)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 75)).eval(FILE);
     Assert.assertTrue("Should read: id between lower and upper bounds", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 79)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 79)).eval(FILE);
     Assert.assertTrue("Should read: id equal to upper bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 80)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 80)).eval(FILE);
     Assert.assertTrue("Should read: id above upper bound", shouldRead);
 
-    shouldRead = new MetricsEvaluator(SCHEMA, notEqual("id", 85)).eval(FILE);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notEqual("id", 85)).eval(FILE);
     Assert.assertTrue("Should read: id above upper bound", shouldRead);
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iceberg.expressions;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.iceberg.DataFile;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.TestHelpers;
+import com.netflix.iceberg.TestHelpers.Row;
+import com.netflix.iceberg.TestHelpers.TestDataFile;
+import com.netflix.iceberg.exceptions.ValidationException;
+import com.netflix.iceberg.types.Types;
+import com.netflix.iceberg.types.Types.IntegerType;
+import com.netflix.iceberg.types.Types.StringType;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static com.netflix.iceberg.expressions.Expressions.and;
+import static com.netflix.iceberg.expressions.Expressions.equal;
+import static com.netflix.iceberg.expressions.Expressions.greaterThan;
+import static com.netflix.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.isNull;
+import static com.netflix.iceberg.expressions.Expressions.lessThan;
+import static com.netflix.iceberg.expressions.Expressions.lessThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.not;
+import static com.netflix.iceberg.expressions.Expressions.notEqual;
+import static com.netflix.iceberg.expressions.Expressions.notNull;
+import static com.netflix.iceberg.expressions.Expressions.or;
+import static com.netflix.iceberg.types.Conversions.toByteBuffer;
+import static com.netflix.iceberg.types.Types.NestedField.optional;
+import static com.netflix.iceberg.types.Types.NestedField.required;
+
+public class TestStrictMetricsEvaluator {
+  private static final Schema SCHEMA = new Schema(
+      required(1, "id", IntegerType.get()),
+      optional(2, "no_stats", IntegerType.get()),
+      required(3, "required", StringType.get()),
+      optional(4, "all_nulls", StringType.get()),
+      optional(5, "some_nulls", StringType.get()),
+      optional(6, "no_nulls", StringType.get()),
+      required(7, "always_5", IntegerType.get())
+  );
+
+  private static final DataFile FILE = new TestDataFile("file.avro", Row.of(), 50,
+      // any value counts, including nulls
+      ImmutableMap.of(
+          4, 50L,
+          5, 50L,
+          6, 50L),
+      // null value counts
+      ImmutableMap.of(
+          4, 50L,
+          5, 10L,
+          6, 0L),
+      // lower bounds
+      ImmutableMap.of(
+          1, toByteBuffer(IntegerType.get(), 30),
+          7, toByteBuffer(IntegerType.get(), 5)),
+      // upper bounds
+      ImmutableMap.of(
+          1, toByteBuffer(IntegerType.get(), 79),
+          7, toByteBuffer(IntegerType.get(), 5)));
+
+  @Test
+  public void testAllNulls() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
+    Assert.assertFalse("Should not match: no non-null value in all null column", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("some_nulls")).eval(FILE);
+    Assert.assertFalse("Should not match: column with some nulls contains a non-null value", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("no_nulls")).eval(FILE);
+    Assert.assertTrue("Should match: non-null column contains no null values", shouldRead);
+  }
+
+  @Test
+  public void testNoNulls() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("all_nulls")).eval(FILE);
+    Assert.assertTrue("Should match: all values are null", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("some_nulls")).eval(FILE);
+    Assert.assertFalse("Should not match: not all values are null", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("no_nulls")).eval(FILE);
+    Assert.assertFalse("Should not match: no values are null", shouldRead);
+  }
+
+  @Test
+  public void testRequiredColumn() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("required")).eval(FILE);
+    Assert.assertTrue("Should match: required columns are always non-null", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("required")).eval(FILE);
+    Assert.assertFalse("Should not match: required columns never contain null", shouldRead);
+  }
+
+  @Test
+  public void testMissingColumn() {
+    TestHelpers.assertThrows("Should complain about missing column in expression",
+        ValidationException.class, "Cannot find field 'missing'",
+        () -> new StrictMetricsEvaluator(SCHEMA, lessThan("missing", 5)).eval(FILE));
+  }
+
+  @Test
+  public void testMissingStats() {
+    DataFile missingStats = new TestDataFile("file.parquet", Row.of(), 50);
+
+    Expression[] exprs = new Expression[] {
+        lessThan("no_stats", 5), lessThanOrEqual("no_stats", 30), equal("no_stats", 70),
+        greaterThan("no_stats", 78), greaterThanOrEqual("no_stats", 90), notEqual("no_stats", 101),
+        isNull("no_stats"), notNull("no_stats")
+    };
+
+    for (Expression expr : exprs) {
+      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, expr).eval(missingStats);
+      Assert.assertFalse("Should never match when stats are missing for expr: " + expr, shouldRead);
+    }
+  }
+
+  @Test
+  public void testZeroRecordFile() {
+    DataFile empty = new TestDataFile("file.parquet", Row.of(), 0);
+
+    Expression[] exprs = new Expression[] {
+        lessThan("id", 5), lessThanOrEqual("id", 30), equal("id", 70), greaterThan("id", 78),
+        greaterThanOrEqual("id", 90), notEqual("id", 101), isNull("some_nulls"),
+        notNull("some_nulls")
+    };
+
+    for (Expression expr : exprs) {
+      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, expr).eval(empty);
+      Assert.assertTrue("Should always match 0-record file: " + expr, shouldRead);
+    }
+  }
+
+  @Test
+  public void testNot() {
+    // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, not(lessThan("id", 5))).eval(FILE);
+    Assert.assertTrue("Should not match: not(false)", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(greaterThan("id", 5))).eval(FILE);
+    Assert.assertFalse("Should match: not(true)", shouldRead);
+  }
+
+  @Test
+  public void testAnd() {
+    // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        and(greaterThan("id", 5), lessThanOrEqual("id", 30))).eval(FILE);
+    Assert.assertFalse("Should not match: range overlaps data", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        and(lessThan("id", 5), greaterThanOrEqual("id", 0))).eval(FILE);
+    Assert.assertFalse("Should match: range does not overlap data", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        and(lessThan("id", 85), greaterThanOrEqual("id", 0))).eval(FILE);
+    Assert.assertTrue("Should match: range includes all data", shouldRead);
+  }
+
+  @Test
+  public void testOr() {
+    // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        or(lessThan("id", 5), greaterThanOrEqual("id", 80))).eval(FILE);
+    Assert.assertFalse("Should not match: no matching values", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        or(lessThan("id", 5), greaterThanOrEqual("id", 60))).eval(FILE);
+    Assert.assertFalse("Should not match: some values do not match", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        or(lessThan("id", 5), greaterThanOrEqual("id", 30))).eval(FILE);
+    Assert.assertTrue("Should match: all values match > 30", shouldRead);
+  }
+
+  @Test
+  public void testIntegerLt() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", 30)).eval(FILE);
+    Assert.assertFalse("Should not match: always false", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", 31)).eval(FILE);
+    Assert.assertFalse("Should not match: 32 and greater not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", 79)).eval(FILE);
+    Assert.assertFalse("Should not match: 79 not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", 80)).eval(FILE);
+    Assert.assertTrue("Should match: all values in range", shouldRead);
+  }
+
+  @Test
+  public void testIntegerLtEq() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 29)).eval(FILE);
+    Assert.assertFalse("Should not match: always false", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 30)).eval(FILE);
+    Assert.assertFalse("Should not match: 31 and greater not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 79)).eval(FILE);
+    Assert.assertTrue("Should match: all values in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", 80)).eval(FILE);
+    Assert.assertTrue("Should match: all values in range", shouldRead);
+  }
+
+  @Test
+  public void testIntegerGt() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("id", 79)).eval(FILE);
+    Assert.assertFalse("Should not match: always false", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("id", 78)).eval(FILE);
+    Assert.assertFalse("Should not match: 77 and less not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("id", 30)).eval(FILE);
+    Assert.assertFalse("Should not match: 30 not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("id", 29)).eval(FILE);
+    Assert.assertTrue("Should match: all values in range", shouldRead);
+  }
+
+  @Test
+  public void testIntegerGtEq() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 80)).eval(FILE);
+    Assert.assertFalse("Should not match: no values in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 79)).eval(FILE);
+    Assert.assertFalse("Should not match: 78 and lower are not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 31)).eval(FILE);
+    Assert.assertFalse("Should not match: 30 not in range", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", 30)).eval(FILE);
+    Assert.assertTrue("Should match: all values in range", shouldRead);
+  }
+
+  @Test
+  public void testIntegerEq() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", 5)).eval(FILE);
+    Assert.assertFalse("Should not match: all values != 5", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", 30)).eval(FILE);
+    Assert.assertFalse("Should not match: some values != 30", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", 75)).eval(FILE);
+    Assert.assertFalse("Should not match: some values != 75", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", 79)).eval(FILE);
+    Assert.assertFalse("Should not match: some values != 79", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", 80)).eval(FILE);
+    Assert.assertFalse("Should not match: some values != 80", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("always_5", 5)).eval(FILE);
+    Assert.assertTrue("Should match: all values == 5", shouldRead);
+  }
+
+  @Test
+  public void testIntegerNotEq() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 5)).eval(FILE);
+    Assert.assertTrue("Should match: no values == 5", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 29)).eval(FILE);
+    Assert.assertTrue("Should match: no values == 39", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 30)).eval(FILE);
+    Assert.assertFalse("Should not match: some value may be == 30", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 75)).eval(FILE);
+    Assert.assertFalse("Should not match: some value may be == 75", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 79)).eval(FILE);
+    Assert.assertFalse("Should not match: some value may be == 79", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 80)).eval(FILE);
+    Assert.assertTrue("Should match: no values == 80", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", 85)).eval(FILE);
+    Assert.assertTrue("Should read: no values == 85", shouldRead);
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/FilteredManifest.java
+++ b/core/src/main/java/com/netflix/iceberg/FilteredManifest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Iterators;
 import com.netflix.iceberg.expressions.Evaluator;
 import com.netflix.iceberg.expressions.Expression;
 import com.netflix.iceberg.expressions.Expressions;
-import com.netflix.iceberg.expressions.MetricsEvaluator;
+import com.netflix.iceberg.expressions.InclusiveMetricsEvaluator;
 import com.netflix.iceberg.expressions.Projections;
 import java.util.Collection;
 import java.util.Iterator;
@@ -66,7 +66,9 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
   @Override
   public Iterator<DataFile> iterator() {
     Evaluator evaluator = new Evaluator(reader.spec().partitionType(), partFilter);
-    MetricsEvaluator metricsEvaluator = new MetricsEvaluator(reader.spec().schema(), rowFilter);
+    InclusiveMetricsEvaluator metricsEvaluator =
+        new InclusiveMetricsEvaluator(reader.spec().schema(), rowFilter);
+
     return Iterators.transform(
         Iterators.filter(reader.iterator(partFilter, columns),
             input -> (input != null &&

--- a/core/src/main/java/com/netflix/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/ValueWriters.java
@@ -202,6 +202,8 @@ public class ValueWriters {
         encoder.writeString((Utf8) s);
       } else if (s instanceof String) {
         encoder.writeString(new Utf8((String) s));
+      } else if (s == null) {
+        throw new IllegalArgumentException("Cannot write null to required string column");
       } else {
         throw new IllegalArgumentException(
             "Cannot write unknown string type: " + s.getClass().getName() + ": " + s.toString());


### PR DESCRIPTION
This adds an evaluator for expressions that returns true if and only if all records in a file must match the expression. This is used to determine whether files can be deleted because all of the data in the file matches the delete expression.

For example, `DELETE FROM table WHERE ts < current_time()` would match all data in a table, even though current time is not at a partition boundary. Using file stats, Iceberg can determine that this is true for all files and can safely delete the data.