### PR TITLE
Use a consistent classloader for Avro reads.

### DIFF
--- a/core/src/main/java/com/netflix/iceberg/avro/Avro.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/Avro.java
@@ -140,11 +140,16 @@ public class Avro {
   }
 
   public static class ReadBuilder {
+    private final ClassLoader defaultLoader = Thread.currentThread().getContextClassLoader();
     private final InputFile file;
     private final Map<String, String> renames = Maps.newLinkedHashMap();
     private boolean reuseContainers = false;
     private com.netflix.iceberg.Schema schema = null;
-    private Function<Schema, DatumReader<?>> createReaderFunc = GenericAvroReader::new;
+    private Function<Schema, DatumReader<?>> createReaderFunc = schema -> {
+      GenericAvroReader<?> reader = new GenericAvroReader<>(schema);
+      reader.setClassLoader(defaultLoader);
+      return reader;
+    };
     private Long start = null;
     private Long length = null;
 


### PR DESCRIPTION
Presto's context classloader was changing from when a scan is created to
when its manifests are read. This was causing Iceberg classes to be
unavailable when loaded dynamically because the context classloader was
used.

This fix sets the classloader to use when the Avro read is started using
the read builder.