### PR TITLE
Fix record name conflict when converting schemas to Avro.

### DIFF
--- a/core/src/main/java/com/netflix/iceberg/ManifestReader.java
+++ b/core/src/main/java/com/netflix/iceberg/ManifestReader.java
@@ -193,7 +193,9 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
             .project(schema)
             .rename("manifest_entry", ManifestEntry.class.getName())
             .rename("partition", PartitionData.class.getName())
+            .rename("r102", PartitionData.class.getName())
             .rename("data_file", GenericDataFile.class.getName())
+            .rename("r2", GenericDataFile.class.getName())
             .reuseContainers()
             .build();
 

--- a/core/src/main/java/com/netflix/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/TypeToSchema.java
@@ -78,7 +78,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
     String recordName = names.get(struct);
     if (recordName == null) {
-      recordName = fieldNames.peek();
+      recordName = "r" + fieldIds.peek();
     }
 
     List<Types.NestedField> structFields = struct.fields();


### PR DESCRIPTION
Using the last field name for the record name breaks when Avro tries to
index a schema by record names, which happens in toString. The fix is to
create record names using the record's field ID. This maintains stable
record names, but ensures records within a schema never conflict.