### PR TITLE
WIP- SparkTableUtil: Fix cases with no file stats.

### DIFF
--- a/spark/src/main/scala/com/netflix/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/com/netflix/iceberg/spark/SparkTableUtil.scala
@@ -131,7 +131,7 @@ object SparkTableUtil {
   }
 
   private def bytesMapToArray(map: java.util.Map[Integer, ByteBuffer]): Seq[Array[Byte]] = {
-    if (map != null) {
+    if (map != null && !map.isEmpty) {
       val keys = map.keySet.asScala
       val max = keys.max
       val arr = Array.fill(max + 1)(null.asInstanceOf[Array[Byte]])


### PR DESCRIPTION
Small fix to the java.lang.UnsupportedOperationException: empty.max in SparkTableUtil.bytesMapToArray (Not sure if its worthy for PR)