### PR TITLE
Add single table transactions.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Transaction.java
+++ b/api/src/main/java/com/netflix/iceberg/Transaction.java
@@ -16,75 +16,19 @@
 
 package com.netflix.iceberg;
 
-import java.util.Map;
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import com.netflix.iceberg.exceptions.ValidationException;
 
 /**
- * Represents a table.
+ * A transaction for performing multiple updates to a table.
  */
-public interface Table {
-
+public interface Transaction {
   /**
-   * Refresh the current table metadata.
-   */
-  void refresh();
-
-  /**
-   * Create a new {@link TableScan scan} for this table.
-   * <p>
-   * Once a table scan is created, it can be refined to project columns and filter data.
+   * Return the {@link Table} that this transaction will update.
    *
-   * @return a table scan for this table
+   * @return this transaction's table
    */
-  TableScan newScan();
-
-  /**
-   * Return the {@link Schema schema} for this table.
-   *
-   * @return this table's schema
-   */
-  Schema schema();
-
-  /**
-   * Return the {@link PartitionSpec partition spec} for this table.
-   *
-   * @return this table's partition spec
-   */
-  PartitionSpec spec();
-
-  /**
-   * Return a map of string properties for this table.
-   *
-   * @return this table's properties map
-   */
-  Map<String, String> properties();
-
-  /**
-   * Return the table's base location.
-   *
-   * @return this table's location
-   */
-  String location();
-
-  /**
-   * Get the current {@link Snapshot snapshot} for this table.
-   *
-   * @return the current table Snapshot.
-   */
-  Snapshot currentSnapshot();
-
-  /**
-   * Get the {@link Snapshot snapshots} of this table.
-   *
-   * @return an Iterable of snapshots of this table.
-   */
-  Iterable<Snapshot> snapshots();
-
-  /**
-   * Create a new {@link UpdateSchema} to alter the columns of this table and commit the change.
-   *
-   * @return a new {@link UpdateSchema}
-   */
-  UpdateSchema updateSchema();
+  Table table();
 
   /**
    * Create a new {@link UpdateProperties} to update table properties and commit the changes.
@@ -138,16 +82,10 @@ public interface Table {
   ExpireSnapshots expireSnapshots();
 
   /**
-   * Create a new {@link Rollback rollback API} to roll back to a previous snapshot and commit.
+   * Apply the pending changes from all actions and commit.
    *
-   * @return a new {@link Rollback}
+   * @throws ValidationException If any update cannot be applied to the current table metadata.
+   * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
-  Rollback rollback();
-
-  /**
-   * Create a new {@link Transaction transaction API} to commit multiple table operations at once.
-   *
-   * @return a new {@link Transaction}
-   */
-  Transaction newTransaction();
+  void commitTransaction();
 }

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
@@ -56,6 +56,18 @@ public abstract class BaseMetastoreTables implements Tables {
     return new BaseTable(ops, database + "." + table);
   }
 
+  public Transaction beginCreate(Schema schema, PartitionSpec spec, String database, String table) {
+    TableOperations ops = newTableOps(conf, database, table);
+    if (ops.current() != null) {
+      throw new AlreadyExistsException("Table already exists: " + database + "." + table);
+    }
+
+    String location = defaultWarehouseLocation(conf, database, table);
+    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, location);
+
+    return BaseTransaction.createTableTransaction(ops, metadata);
+  }
+
   private static String defaultWarehouseLocation(Configuration conf, String database, String table) {
     String warehouseLocation = conf.get("hive.metastore.warehouse.dir");
     Preconditions.checkNotNull(warehouseLocation,

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
@@ -28,7 +28,7 @@ public abstract class BaseMetastoreTables implements Tables {
     this.conf = conf;
   }
 
-  public abstract BaseMetastoreTableOperations newTableOps(Configuration conf, String database, String table);
+  protected abstract BaseMetastoreTableOperations newTableOps(Configuration conf, String database, String table);
 
   public Table load(String database, String table) {
     TableOperations ops = newTableOps(conf, database, table);

--- a/core/src/main/java/com/netflix/iceberg/BaseTable.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTable.java
@@ -113,6 +113,11 @@ public class BaseTable implements Table {
   }
 
   @Override
+  public Transaction newTransaction() {
+    return BaseTransaction.newTransaction(ops);
+  }
+
+  @Override
   public String toString() {
     return name;
   }

--- a/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import com.netflix.iceberg.io.InputFile;
+import com.netflix.iceberg.io.OutputFile;
+import com.netflix.iceberg.util.Tasks;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static com.netflix.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
+
+// TODO: ensure this correctly cleans up unused manifests created by SnapshotUpdates
+class BaseTransaction implements Transaction {
+  static Transaction createTableTransaction(TableOperations ops, TableMetadata start) {
+    Preconditions.checkArgument(ops.current() == null,
+        "Cannot start create table transaction: table already exists");
+    return new BaseTransaction(ops, start);
+  }
+
+  static Transaction newTransaction(TableOperations ops) {
+    return new BaseTransaction(ops, ops.refresh());
+  }
+
+  private final TransactionTable transactionTable;
+  private final TableOperations ops;
+  private final TableOperations transactionOps;
+  private final List<PendingUpdate> updates;
+  private TableMetadata base;
+  private TableMetadata lastBase;
+  private TableMetadata current;
+
+  private BaseTransaction(TableOperations ops, TableMetadata start) {
+    this.transactionTable = new TransactionTable();
+    this.ops = ops;
+    this.transactionOps = new TransactionTableOperations();
+    this.updates = Lists.newArrayList();
+    this.base = ops.current();
+    this.lastBase = null;
+    this.current = start;
+  }
+
+  @Override
+  public Table table() {
+    return transactionTable;
+  }
+
+  private void checkLastOperationCommitted(String operation) {
+    Preconditions.checkState(lastBase != current,
+        "Cannot create new %s: last operation (%s) is not committed", operation,
+        updates.get(updates.size() - 1).getClass().getSimpleName());
+    this.lastBase = current;
+  }
+
+  @Override
+  public UpdateProperties updateProperties() {
+    checkLastOperationCommitted("UpdateProperties");
+    UpdateProperties props = new PropertiesUpdate(transactionOps);
+    updates.add(props);
+    return props;
+  }
+
+  @Override
+  public AppendFiles newAppend() {
+    checkLastOperationCommitted("AppendFiles");
+    AppendFiles append = new MergeAppend(transactionOps);
+    updates.add(append);
+    return append;
+  }
+
+  @Override
+  public RewriteFiles newRewrite() {
+    checkLastOperationCommitted("RewriteFiles");
+    RewriteFiles rewrite = new ReplaceFiles(transactionOps);
+    updates.add(rewrite);
+    return rewrite;
+  }
+
+  @Override
+  public DeleteFiles newDelete() {
+    checkLastOperationCommitted("DeleteFiles");
+    DeleteFiles delete = new StreamingDelete(transactionOps);
+    updates.add(delete);
+    return delete;
+  }
+
+  @Override
+  public ExpireSnapshots expireSnapshots() {
+    checkLastOperationCommitted("ExpireSnapshots");
+    ExpireSnapshots expire = new RemoveSnapshots(transactionOps);
+    updates.add(expire);
+    return expire;
+  }
+
+  @Override
+  public void commitTransaction() {
+    if (base != null) {
+      // first try to commit the update chain as-is in case it will succeed
+      boolean committed = false;
+      if (base == ops.refresh()) {
+        try {
+          ops.commit(base, current);
+          committed = true;
+        } catch (CommitFailedException e) {
+          // will retry because committed is false
+        }
+      }
+
+      if (!committed) {
+        Tasks.foreach(ops)
+            .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+            .exponentialBackoff(
+                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+                2.0 /* exponential */)
+            .onlyRetryOn(CommitFailedException.class)
+            .run(ops -> {
+              this.base = ops.refresh();
+              this.current = base;
+              for (PendingUpdate update : updates) {
+                // re-commit each update in the chain to apply it and update current
+                update.commit();
+              }
+              ops.commit(base, current);
+            });
+      }
+
+    } else {
+      // this operation creates the table. if the commit fails, this cannot retry because another
+      // process has created the same table.
+      ops.commit(null, current);
+    }
+  }
+
+  public class TransactionTableOperations implements TableOperations {
+    @Override
+    public TableMetadata current() {
+      return current;
+    }
+
+    @Override
+    public TableMetadata refresh() {
+      return current;
+    }
+
+    @Override
+    public void commit(TableMetadata base, TableMetadata metadata) {
+      if (base != current) {
+        // trigger a refresh and retry
+        throw new CommitFailedException("Table metadata refresh is required");
+      }
+      BaseTransaction.this.current = metadata;
+    }
+
+    @Override
+    public InputFile newInputFile(String path) {
+      return ops.newInputFile(path);
+    }
+
+    @Override
+    public OutputFile newMetadataFile(String filename) {
+      return ops.newMetadataFile(filename);
+    }
+
+    @Override
+    public void deleteFile(String path) {
+      ops.deleteFile(path);
+    }
+
+    @Override
+    public long newSnapshotId() {
+      return ops.newSnapshotId();
+    }
+  }
+
+  public class TransactionTable implements Table {
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public TableScan newScan() {
+      throw new UnsupportedOperationException("Transaction tables do not support scans");
+    }
+
+    @Override
+    public Schema schema() {
+      return current.schema();
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return current.spec();
+    }
+
+    @Override
+    public Map<String, String> properties() {
+      return current.properties();
+    }
+
+    @Override
+    public String location() {
+      return current.location();
+    }
+
+    @Override
+    public Snapshot currentSnapshot() {
+      return current.currentSnapshot();
+    }
+
+    @Override
+    public Iterable<Snapshot> snapshots() {
+      return current.snapshots();
+    }
+
+    @Override
+    public UpdateSchema updateSchema() {
+      throw new UnsupportedOperationException("Transaction tables do not support schema updates");
+    }
+
+    @Override
+    public UpdateProperties updateProperties() {
+      return BaseTransaction.this.updateProperties();
+    }
+
+    @Override
+    public AppendFiles newAppend() {
+      return BaseTransaction.this.newAppend();
+    }
+
+    @Override
+    public RewriteFiles newRewrite() {
+      return BaseTransaction.this.newRewrite();
+    }
+
+    @Override
+    public DeleteFiles newDelete() {
+      return BaseTransaction.this.newDelete();
+    }
+
+    @Override
+    public ExpireSnapshots expireSnapshots() {
+      return BaseTransaction.this.expireSnapshots();
+    }
+
+    @Override
+    public Rollback rollback() {
+      throw new UnsupportedOperationException("Transaction tables do not support rollback");
+    }
+
+    @Override
+    public Transaction newTransaction() {
+      throw new UnsupportedOperationException("Cannot create a transaction within a transaction");
+    }
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
@@ -71,8 +71,7 @@ class BaseTransaction implements Transaction {
 
   private void checkLastOperationCommitted(String operation) {
     Preconditions.checkState(lastBase != current,
-        "Cannot create new %s: last operation (%s) is not committed", operation,
-        updates.get(updates.size() - 1).getClass().getSimpleName());
+        "Cannot create new %s: last operation has not committed", operation);
     this.lastBase = current;
   }
 

--- a/core/src/main/java/com/netflix/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/com/netflix/iceberg/PropertiesUpdate.java
@@ -17,12 +17,10 @@
 package com.netflix.iceberg;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.CommitFailedException;
 import com.netflix.iceberg.util.Tasks;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 

--- a/core/src/test/java/com/netflix/iceberg/TableTestBase.java
+++ b/core/src/test/java/com/netflix/iceberg/TableTestBase.java
@@ -16,14 +16,19 @@
 
 package com.netflix.iceberg;
 
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.netflix.iceberg.types.Types;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 
 import static com.netflix.iceberg.types.Types.NestedField.required;
@@ -70,7 +75,6 @@ public class TableTestBase {
 
   File tableDir = null;
   File metadataDir = null;
-  File versionHintFile = null;
   TestTables.TestTable table = null;
 
   @Before
@@ -79,7 +83,6 @@ public class TableTestBase {
     tableDir.delete(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
-    this.versionHintFile = new File(metadataDir, "version-hint.text");
     this.table = create(SCHEMA, SPEC);
   }
 
@@ -89,7 +92,11 @@ public class TableTestBase {
   }
 
   List<File> listMetadataFiles(String ext) {
-    return Lists.newArrayList(metadataDir.listFiles(
+    return listMetadataFiles(tableDir, ext);
+  }
+
+  List<File> listMetadataFiles(File tableDir, String ext) {
+    return Lists.newArrayList(new File(tableDir, "metadata").listFiles(
         (dir, name) -> Files.getFileExtension(name).equalsIgnoreCase(ext)));
   }
 
@@ -103,5 +110,39 @@ public class TableTestBase {
 
   TableMetadata readMetadata() {
     return TestTables.readMetadata("test");
+  }
+
+  void validateSnapshot(Snapshot old, Snapshot snap, DataFile... newFiles) {
+    List<String> oldManifests = old != null ? old.manifests() : ImmutableList.of();
+
+    // copy the manifests to a modifiable list and remove the existing manifests
+    List<String> newManifests = Lists.newArrayList(snap.manifests());
+    for (String oldManifest : oldManifests) {
+      Assert.assertTrue("New snapshot should contain old manifests",
+          newManifests.remove(oldManifest));
+    }
+
+    Assert.assertEquals("Should create 1 new manifest and reuse old manifests",
+        1, newManifests.size());
+    String manifest = newManifests.get(0);
+
+    long id = snap.snapshotId();
+    Iterator<String> newPaths = paths(newFiles).iterator();
+
+    for (ManifestEntry entry : ManifestReader.read(com.netflix.iceberg.Files.localInput(manifest)).entries()) {
+      DataFile file = entry.file();
+      Assert.assertEquals("Path should match expected", newPaths.next(), file.path().toString());
+      Assert.assertEquals("File's snapshot ID should match", id, entry.snapshotId());
+    }
+
+    Assert.assertFalse("Should find all files in the manifest", newPaths.hasNext());
+  }
+
+  List<String> paths(DataFile... dataFiles) {
+    List<String> paths = Lists.newArrayListWithExpectedSize(dataFiles.length);
+    for (DataFile file : dataFiles) {
+      paths.add(file.path().toString());
+    }
+    return paths;
   }
 }

--- a/core/src/test/java/com/netflix/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/com/netflix/iceberg/TestCreateTransaction.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import com.netflix.iceberg.types.TypeUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.netflix.iceberg.PartitionSpec.unpartitioned;
+
+public class TestCreateTransaction extends TableTestBase {
+  @Test
+  public void testCreateTransaction() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_create", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_create"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_create"));
+
+    t.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_create");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_create"));
+    Assert.assertEquals("Should have 0 manifest files",
+        0, listMetadataFiles(tableDir, "avro").size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
+  }
+
+  @Test
+  public void testCreateAndAppendWithTransaction() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_append", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertNull("Appending in a transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    t.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_append");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_append"));
+    Assert.assertEquals("Should have 1 manifest file",
+        1, listMetadataFiles(tableDir, "avro").size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+
+    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+  }
+
+  @Test
+  public void testCreateAndAppendWithTable() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_append", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    Assert.assertTrue("Should return a transaction table",
+        t.table() instanceof BaseTransaction.TransactionTable);
+
+    t.table().newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertNull("Appending in a transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    t.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_append");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_append"));
+    Assert.assertEquals("Should have 1 manifest file",
+        1, listMetadataFiles(tableDir, "avro").size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+
+    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+  }
+
+  @Test
+  public void testCreateAndUpdatePropertiesWithTransaction() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_properties", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_properties"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_properties"));
+
+    t.updateProperties()
+        .set("test-property", "test-value")
+        .commit();
+
+    Assert.assertNull("Adding properties in a transaction should not commit metadata",
+        TestTables.readMetadata("test_properties"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_properties"));
+
+    t.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_properties");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_properties"));
+    Assert.assertEquals("Should have 0 manifest files",
+        0, listMetadataFiles(tableDir, "avro").size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
+    Assert.assertEquals("Should have one table property", 1, meta.properties().size());
+    Assert.assertEquals("Should have correct table property value",
+        "test-value", meta.properties().get("test-property"));
+  }
+
+  @Test
+  public void testCreateAndUpdatePropertiesWithTable() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_properties", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_properties"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_properties"));
+
+    Assert.assertTrue("Should return a transaction table",
+        t.table() instanceof BaseTransaction.TransactionTable);
+
+    t.table().updateProperties()
+        .set("test-property", "test-value")
+        .commit();
+
+    Assert.assertNull("Adding properties in a transaction should not commit metadata",
+        TestTables.readMetadata("test_properties"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_properties"));
+
+    t.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_properties");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_properties"));
+    Assert.assertEquals("Should have 0 manifest files",
+        0, listMetadataFiles(tableDir, "avro").size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
+    Assert.assertEquals("Should have one table property", 1, meta.properties().size());
+    Assert.assertEquals("Should have correct table property value",
+        "test-value", meta.properties().get("test-property"));
+  }
+
+  @Test
+  public void testCreateTransactionConflict() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction t = TestTables.beginCreate(tableDir, "test_conflict", SCHEMA, SPEC);
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_conflict"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_conflict"));
+
+    Table conflict = TestTables.create(tableDir, "test_conflict", SCHEMA, unpartitioned());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), conflict.schema().asStruct());
+    Assert.assertEquals("Table spec should match conflict table, not transaction table",
+        unpartitioned(), conflict.spec());
+    Assert.assertFalse("Table should not have any snapshots",
+        conflict.snapshots().iterator().hasNext());
+
+    AssertHelpers.assertThrows("Transaction commit should fail",
+        CommitFailedException.class, "Commit failed: table was updated", t::commitTransaction);
+  }
+
+  private static Schema assignFreshIds(Schema schema) {
+    AtomicInteger lastColumnId = new AtomicInteger(0);
+    return TypeUtil.assignFreshIds(schema, lastColumnId::incrementAndGet);
+  }
+}

--- a/core/src/test/java/com/netflix/iceberg/TestFastAppend.java
+++ b/core/src/test/java/com/netflix/iceberg/TestFastAppend.java
@@ -189,38 +189,4 @@ public class TestFastAppend extends TableTestBase {
     Assert.assertTrue("Should commit the same new manifest",
         metadata.currentSnapshot().manifests().contains(newManifest));
   }
-
-  private void validateSnapshot(Snapshot old, Snapshot snap, DataFile... newFiles) {
-    List<String> oldManifests = old != null ? old.manifests() : ImmutableList.of();
-
-    // copy the manifests to a modifiable list and remove the existing manifests
-    List<String> newManifests = Lists.newArrayList(snap.manifests());
-    for (String oldManifest : oldManifests) {
-      Assert.assertTrue("New snapshot should contain old manifests",
-          newManifests.remove(oldManifest));
-    }
-
-    Assert.assertEquals("Should create 1 new manifest and reuse old manifests",
-        1, newManifests.size());
-    String manifest = newManifests.get(0);
-
-    long id = snap.snapshotId();
-    Iterator<String> newPaths = paths(newFiles).iterator();
-
-    for (ManifestEntry entry : ManifestReader.read(Files.localInput(manifest)).entries()) {
-      DataFile file = entry.file();
-      Assert.assertEquals("Path should match expected", newPaths.next(), file.path().toString());
-      Assert.assertEquals("File's snapshot ID should match", id, entry.snapshotId());
-    }
-
-    Assert.assertFalse("Should find all files in the manifest", newPaths.hasNext());
-  }
-
-  private List<String> paths(DataFile... dataFiles) {
-    List<String> paths = Lists.newArrayListWithExpectedSize(dataFiles.length);
-    for (DataFile file : dataFiles) {
-      paths.add(file.path().toString());
-    }
-    return paths;
-  }
 }

--- a/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
@@ -16,14 +16,12 @@
 
 package com.netflix.iceberg;
 
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.CommitFailedException;
 import org.junit.Assert;
 import org.junit.Test;
 import java.io.File;
-import java.util.Iterator;
 import java.util.Set;
 
 import static com.google.common.collect.Iterators.concat;
@@ -321,32 +319,5 @@ public class TestMergeAppend extends TableTestBase {
     Assert.assertTrue("Should reuse the new manifest", new File(newManifest).exists());
     Assert.assertEquals("Should commit the same new manifest during retry",
         Lists.newArrayList(newManifest), metadata.currentSnapshot().manifests());
-  }
-
-  private void validateManifest(String manifest,
-                                Iterator<Long> ids,
-                                Iterator<DataFile> expectedFiles) {
-    for (ManifestEntry entry : ManifestReader.read(Files.localInput(manifest)).entries()) {
-      DataFile file = entry.file();
-      DataFile expected = expectedFiles.next();
-      Assert.assertEquals("Path should match expected",
-          expected.path().toString(), file.path().toString());
-      Assert.assertEquals("Snapshot ID should match expected ID",
-          (long) ids.next(), entry.snapshotId());
-    }
-
-    Assert.assertFalse("Should find all files in the manifest", expectedFiles.hasNext());
-  }
-
-  private static Iterator<Long> ids(Long... ids) {
-    return Iterators.forArray(ids);
-  }
-
-  private static Iterator<DataFile> files(DataFile... files) {
-    return Iterators.forArray(files);
-  }
-
-  private static Iterator<DataFile> files(String manifest) {
-    return ManifestReader.read(Files.localInput(manifest)).iterator();
   }
 }

--- a/core/src/test/java/com/netflix/iceberg/TestTransaction.java
+++ b/core/src/test/java/com/netflix/iceberg/TestTransaction.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.collect.Sets;
+import com.netflix.iceberg.ManifestEntry.Status;
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import org.junit.Assert;
+import org.junit.Test;
+import java.io.File;
+import java.util.Set;
+
+public class TestTransaction extends TableTestBase {
+  @Test
+  public void testEmptyTransaction() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+    t.commitTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+  }
+
+  @Test
+  public void testSingleOperationTransaction() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertSame("Base metadata should not change when an append is committed",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after append", 0, (int) version());
+
+    t.commitTransaction();
+
+    validateSnapshot(base.currentSnapshot(), readMetadata().currentSnapshot(), FILE_A, FILE_B);
+    Assert.assertEquals("Table should be on version 1 after commit", 1, (int) version());
+  }
+
+  @Test
+  public void testMultipleOperationTransaction() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    Snapshot appendSnapshot = t.table().currentSnapshot();
+
+    t.newDelete()
+        .deleteFile(FILE_A)
+        .commit();
+
+    Snapshot deleteSnapshot = t.table().currentSnapshot();
+
+    Assert.assertSame("Base metadata should not change when an append is committed",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after append", 0, (int) version());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 1 after commit", 1, (int) version());
+    Assert.assertEquals("Table should have one manifest after commit",
+        1, readMetadata().currentSnapshot().manifests().size());
+    Assert.assertEquals("Table snapshot should be the delete snapshot",
+        deleteSnapshot, readMetadata().currentSnapshot());
+    validateManifestEntries(readMetadata().currentSnapshot().manifests().get(0),
+        ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
+        files(FILE_A, FILE_B), statuses(Status.DELETED, Status.EXISTING));
+
+    Assert.assertEquals("Table should have a snapshot for each operation",
+        2, readMetadata().snapshots().size());
+    validateManifestEntries(readMetadata().snapshots().get(0).manifests().get(0),
+        ids(appendSnapshot.snapshotId(), appendSnapshot.snapshotId()),
+        files(FILE_A, FILE_B), statuses(Status.ADDED, Status.ADDED));
+  }
+
+  @Test
+  public void testMultipleOperationTransactionFromTable() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    Snapshot appendSnapshot = t.table().currentSnapshot();
+
+    t.table().newDelete()
+        .deleteFile(FILE_A)
+        .commit();
+
+    Snapshot deleteSnapshot = t.table().currentSnapshot();
+
+    Assert.assertSame("Base metadata should not change when an append is committed",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after append", 0, (int) version());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 1 after commit", 1, (int) version());
+    Assert.assertEquals("Table should have one manifest after commit",
+        1, readMetadata().currentSnapshot().manifests().size());
+    Assert.assertEquals("Table snapshot should be the delete snapshot",
+        deleteSnapshot, readMetadata().currentSnapshot());
+    validateManifestEntries(readMetadata().currentSnapshot().manifests().get(0),
+        ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
+        files(FILE_A, FILE_B), statuses(Status.DELETED, Status.EXISTING));
+
+    Assert.assertEquals("Table should have a snapshot for each operation",
+        2, readMetadata().snapshots().size());
+    validateManifestEntries(readMetadata().snapshots().get(0).manifests().get(0),
+        ids(appendSnapshot.snapshotId(), appendSnapshot.snapshotId()),
+        files(FILE_A, FILE_B), statuses(Status.ADDED, Status.ADDED));
+  }
+
+  @Test
+  public void testDetectsUncommittedChange() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    t.newAppend().appendFile(FILE_A).appendFile(FILE_B); // not committed
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    AssertHelpers.assertThrows("Should reject commit when last operation has not committed",
+        IllegalStateException.class,
+        "Cannot create new DeleteFiles: last operation has not committed",
+        t::newDelete);
+  }
+
+  @Test
+  public void testDetectsUncommittedChangeOnCommit() {
+    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    t.newAppend().appendFile(FILE_A).appendFile(FILE_B); // not committed
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+
+    AssertHelpers.assertThrows("Should reject commit when last operation has not committed",
+        IllegalStateException.class,
+        "Cannot commit transaction: last operation has not committed",
+        t::commitTransaction);
+  }
+
+  @Test
+  public void testTransactionConflict() {
+    // set retries to 0 to catch the failure
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "0")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+
+    // cause the transaction commit to fail
+    table.ops().failCommits(1);
+
+    AssertHelpers.assertThrows("Transaction commit should fail",
+        CommitFailedException.class, "Injected failure", t::commitTransaction);
+  }
+
+  @Test
+  public void testTransactionRetry() {
+    // use only one retry
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Set<String> appendManifests = Sets.newHashSet(t.table().currentSnapshot().manifests());
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+
+    // cause the transaction commit to fail
+    table.ops().failCommits(1);
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 2 after commit", 2, (int) version());
+
+    Assert.assertEquals("Should reuse manifests from initial append commit",
+        appendManifests, Sets.newHashSet(table.currentSnapshot().manifests()));
+  }
+
+  @Test
+  public void testTransactionRetryMergeAppend() {
+    // use only one retry
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Set<String> appendManifests = Sets.newHashSet(t.table().currentSnapshot().manifests());
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+
+    // cause the transaction commit to fail
+    table.newAppend()
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
+
+    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+
+    Set<String> conflictAppendManifests = Sets.newHashSet(table.currentSnapshot().manifests());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+
+    Set<String> expectedManifests = Sets.newHashSet();
+    expectedManifests.addAll(appendManifests);
+    expectedManifests.addAll(conflictAppendManifests);
+
+    Assert.assertEquals("Should reuse manifests from initial append commit and conflicting append",
+        expectedManifests, Sets.newHashSet(table.currentSnapshot().manifests()));
+  }
+
+  @Test
+  public void testMultipleUpdateTransactionRetryMergeCleanup() {
+    // use only one retry and aggressively merge manifests
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+
+    t.updateProperties()
+        .set("test-property", "test-value")
+        .commit();
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertEquals("Append should create one manifest",
+        1, t.table().currentSnapshot().manifests().size());
+    String appendManifest = t.table().currentSnapshot().manifests().get(0);
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+
+    // cause the transaction commit to fail
+    table.newAppend()
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
+
+    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+
+    Set<String> conflictAppendManifests = Sets.newHashSet(table.currentSnapshot().manifests());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+
+    Set<String> previousManifests = Sets.newHashSet();
+    previousManifests.add(appendManifest);
+    previousManifests.addAll(conflictAppendManifests);
+
+    Assert.assertEquals("Should merge both commit manifests into a single manifest",
+        1, table.currentSnapshot().manifests().size());
+    Assert.assertFalse("Should merge both commit manifests into a new manifest",
+        previousManifests.contains(table.currentSnapshot().manifests().get(0)));
+
+    Assert.assertFalse("Append manifest should be deleted", new File(appendManifest).exists());
+  }
+
+  @Test
+  public void testTransactionRetryMergeCleanup() {
+    // use only one retry and aggressively merge manifests
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    TableMetadata base = readMetadata();
+
+    Transaction t = table.newTransaction();
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+
+    t.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertEquals("Append should create one manifest",
+        1, t.table().currentSnapshot().manifests().size());
+    String appendManifest = t.table().currentSnapshot().manifests().get(0);
+
+    Assert.assertSame("Base metadata should not change when commit is created",
+        base, readMetadata());
+    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+
+    // cause the transaction commit to fail
+    table.newAppend()
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
+
+    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+
+    Set<String> conflictAppendManifests = Sets.newHashSet(table.currentSnapshot().manifests());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+
+    Set<String> previousManifests = Sets.newHashSet();
+    previousManifests.add(appendManifest);
+    previousManifests.addAll(conflictAppendManifests);
+
+    Assert.assertEquals("Should merge both commit manifests into a single manifest",
+        1, table.currentSnapshot().manifests().size());
+    Assert.assertFalse("Should merge both commit manifests into a new manifest",
+        previousManifests.contains(table.currentSnapshot().manifests().get(0)));
+
+    Assert.assertFalse("Append manifest should be deleted", new File(appendManifest).exists());
+  }
+}


### PR DESCRIPTION
This adds a Transaction API that exposes some Table updates that can be performed in a single commit.

The transaction works by replacing the underlying TableOperations passed to individual updates with a transaction version that applies changes to the table metadata result of the previous update. If the transaction commit needs to retry, it re-runs commit for each update in order. Each update must be committed before the next update is created to ensure a clear order.

Transaction also returns a table, which can be passed to code that expects a Table instead of a Transaction. Operations on that table become part of the transaction.