### PR TITLE
Add snapshot log to metadata.

### DIFF
--- a/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
@@ -16,6 +16,7 @@
 
 package com.netflix.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.CommitFailedException;
@@ -186,7 +187,7 @@ public class TestMergeAppend extends TableTestBase {
     // commit the new partition spec to the table manually
     TableMetadata updated = new TableMetadata(table.ops(), null, base.location(),
         System.currentTimeMillis(), base.lastColumnId(), base.schema(), newSpec, base.properties(),
-        base.currentSnapshot().snapshotId(), base.snapshots());
+        base.currentSnapshot().snapshotId(), base.snapshots(), ImmutableList.of());
     table.ops().commit(base, updated);
 
     DataFile newFileC = DataFiles.builder(newSpec)
@@ -234,7 +235,7 @@ public class TestMergeAppend extends TableTestBase {
     // commit the new partition spec to the table manually
     TableMetadata updated = new TableMetadata(table.ops(), null, base.location(),
         System.currentTimeMillis(), base.lastColumnId(), base.schema(), newSpec, base.properties(),
-        base.currentSnapshot().snapshotId(), base.snapshots());
+        base.currentSnapshot().snapshotId(), base.snapshots(), ImmutableList.of());
     table.ops().commit(base, updated);
 
     DataFile newFileC = DataFiles.builder(newSpec)

--- a/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
+++ b/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
@@ -17,12 +17,16 @@
 package com.netflix.iceberg;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.netflix.iceberg.TableMetadata.SnapshotLogEntry;
 import com.netflix.iceberg.types.Types;
 import com.netflix.iceberg.util.JsonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class TestTableMetadataJson {
@@ -37,13 +41,20 @@ public class TestTableMetadataJson {
     PartitionSpec spec = PartitionSpec.builderFor(schema).build();
 
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
-    Snapshot previousSnapshot = new BaseSnapshot(null, previousSnapshotId, "file:/tmp/manfiest.1.avro");
+    Snapshot previousSnapshot = new BaseSnapshot(
+        null, previousSnapshotId, previousSnapshotId, ImmutableList.of("file:/tmp/manfiest.1.avro"));
     long currentSnapshotId = System.currentTimeMillis();
-    Snapshot currentSnapshot = new BaseSnapshot(null, currentSnapshotId, "file:/tmp/manfiest.2.avro");
+    Snapshot currentSnapshot = new BaseSnapshot(
+        null, currentSnapshotId, currentSnapshotId, ImmutableList.of("file:/tmp/manfiest.2.avro"));
+
+    List<SnapshotLogEntry> snapshotLog = ImmutableList.<SnapshotLogEntry>builder()
+        .add(new SnapshotLogEntry(previousSnapshot.timestampMillis(), previousSnapshot.snapshotId()))
+        .add(new SnapshotLogEntry(currentSnapshot.timestampMillis(), currentSnapshot.snapshotId()))
+        .build();
 
     TableMetadata expected = new TableMetadata(null, null, "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, spec, ImmutableMap.of("property", "value"),
-        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot));
+        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog);
 
     String asJson = TableMetadataParser.toJson(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(null, null,
@@ -59,6 +70,8 @@ public class TestTableMetadataJson {
         expected.spec().toString(), metadata.spec().toString());
     Assert.assertEquals("Properties should match",
         expected.properties(), metadata.properties());
+    Assert.assertEquals("Snapshot logs should match",
+        expected.snapshotLog(), metadata.snapshotLog());
     Assert.assertEquals("Current snapshot ID should match",
         currentSnapshotId, metadata.currentSnapshot().snapshotId());
     Assert.assertEquals("Current snapshot files should match",
@@ -68,5 +81,47 @@ public class TestTableMetadataJson {
     Assert.assertEquals("Previous snapshot files should match",
         previousSnapshot.manifests(),
         metadata.snapshot(previousSnapshotId).manifests());
+  }
+
+  @Test
+  public void testFromJsonSortsSnapshotLog() throws Exception {
+    Schema schema = new Schema(
+        Types.NestedField.required(1, "x", Types.LongType.get()),
+        Types.NestedField.required(2, "y", Types.LongType.get()),
+        Types.NestedField.required(3, "z", Types.LongType.get())
+    );
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).build();
+
+    long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Snapshot previousSnapshot = new BaseSnapshot(
+        null, previousSnapshotId, previousSnapshotId, ImmutableList.of("file:/tmp/manfiest.1.avro"));
+    long currentSnapshotId = System.currentTimeMillis();
+    Snapshot currentSnapshot = new BaseSnapshot(
+        null, currentSnapshotId, currentSnapshotId, ImmutableList.of("file:/tmp/manfiest.2.avro"));
+
+    List<SnapshotLogEntry> reversedSnapshotLog = Lists.newArrayList();
+
+    TableMetadata expected = new TableMetadata(null, null, "s3://bucket/test/location",
+        System.currentTimeMillis(), 3, schema, spec, ImmutableMap.of("property", "value"),
+        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog);
+
+    // add the entries after creating TableMetadata to avoid the sorted check
+    reversedSnapshotLog.add(
+        new SnapshotLogEntry(currentSnapshot.timestampMillis(), currentSnapshot.snapshotId()));
+    reversedSnapshotLog.add(
+        new SnapshotLogEntry(previousSnapshot.timestampMillis(), previousSnapshot.snapshotId()));
+
+    String asJson = TableMetadataParser.toJson(expected);
+    TableMetadata metadata = TableMetadataParser.fromJson(null, null,
+        JsonUtil.mapper().readValue(asJson, JsonNode.class));
+
+    List<SnapshotLogEntry> expectedSnapshotLog = ImmutableList.<SnapshotLogEntry>builder()
+        .add(new SnapshotLogEntry(previousSnapshot.timestampMillis(), previousSnapshot.snapshotId()))
+        .add(new SnapshotLogEntry(currentSnapshot.timestampMillis(), currentSnapshot.snapshotId()))
+        .build();
+
+    Assert.assertEquals("Snapshot logs should match",
+        expectedSnapshotLog, metadata.snapshotLog());
   }
 }


### PR DESCRIPTION
This is a forward-compatible change and adds metadata that older versions can ignore. This closes #53.