### PR TITLE
Add Hive metastore support

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/exceptions/InitializationException.java
+++ b/api/src/main/java/com/netflix/iceberg/exceptions/InitializationException.java
@@ -1,0 +1,11 @@
+package com.netflix.iceberg.exceptions;
+
+public class InitializationException extends RuntimeException {
+  public InitializationException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  public InitializationException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,7 @@ project(':iceberg-core') {
     compile project(':iceberg-common')
 
     compile "org.apache.avro:avro:$avroVersion"
+    compile "org.apache.hive:hive-metastore:3.1.0"
 
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
@@ -43,9 +43,9 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   public static final String METADATA_LOCATION_PROP = "metadata_location";
   public static final String PREVIOUS_METADATA_LOCATION_PROP = "previous_metadata_location";
 
-  private static final String METADATA_FOLDER_NAME = "metadata";
-  private static final String DATA_FOLDER_NAME = "data";
-  private static final String HIVE_LOCATION_FOLDER_NAME = "empty";
+  protected static final String HIVE_LOCATION_FOLDER_NAME = "empty";
+  protected static final String METADATA_FOLDER_NAME = "metadata";
+  protected static final String DATA_FOLDER_NAME = "data";
 
   private final Configuration conf;
 

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import static com.netflix.iceberg.TableMetadata.newTableMetadata;
 
 public abstract class BaseMetastoreTables implements Tables {
-  private final Configuration conf;
+  protected final Configuration conf;
 
   public BaseMetastoreTables(Configuration conf) {
     this.conf = conf;

--- a/core/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
@@ -1,0 +1,190 @@
+package com.netflix.iceberg.hive;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.netflix.iceberg.BaseMetastoreTableOperations;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.TableMetadata;
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.LockComponent;
+import org.apache.hadoop.hive.metastore.api.LockLevel;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.LockType;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.SerdeType;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.netflix.iceberg.hive.HiveTypeConverter.convert;
+
+/**
+ * TODO we should be able to extract some more commonalities to BaseMetastoreTableOperations to
+ * avoid code duplication between this class and Metacat Tables.
+ */
+public class HiveTableOperations extends BaseMetastoreTableOperations {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveTableOperations.class);
+
+  private final IMetaStoreClient metaStoreClient;
+  private final String catalog; // TODO I am not sure what is catalog in hive metastore context.
+  private final String database;
+  private final String table;
+
+  protected HiveTableOperations(Configuration conf, IMetaStoreClient metaStoreClient, String catalog, String database, String table) {
+    super(conf);
+    this.metaStoreClient = metaStoreClient;
+    this.catalog = catalog;
+    this.database = database;
+    this.table = table;
+  }
+
+  @Override
+  public TableMetadata refresh() {
+    try {
+      final Table table = metaStoreClient.getTable(catalog, database, this.table);
+      String tableType = table.getParameters().get(TABLE_TYPE_PROP);
+
+      Preconditions.checkArgument(
+              tableType != null && tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
+              "Invalid table, not Iceberg: %s.%s.%s", catalog, database, table);
+      String metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
+      Preconditions.checkNotNull(metadataLocation,
+              "Invalid table, missing metadata_location: %s.%s.%s", catalog, database, table);
+    } catch (TException e) {
+      throw new RuntimeException(e);
+    }
+    return current();
+  }
+
+  @Override
+  public void commit(TableMetadata base, TableMetadata metadata) {
+    // if the metadata is already out of date, reject it
+    if (base != current()) {
+      throw new CommitFailedException("Cannot commit changes based on stale table metadata");
+    }
+
+    // if the metadata is not changed, return early
+    if (base == metadata) {
+      LOG.info("Nothing to commit.");
+      return;
+    }
+
+    String newMetadataLocation = writeNewMetadata(metadata, currentVersion() + 1);
+
+    boolean threw = true;
+    Optional<Long> lockId = Optional.empty();
+    try {
+      lockId = acquireLock();
+      // TODO add lock heart beating for cases where default lock timeout is too low.
+      Table tbl;
+      if (base != null) {
+        tbl = metaStoreClient.getTable(catalog, database, this.table);
+      } else {
+        final long currentTimeMillis = System.currentTimeMillis();
+        final StorageDescriptor storageDescriptor = getStorageDescriptor(metadata.schema());
+        tbl = new Table(table,
+                database,
+                System.getProperty("user.name"),
+                (int) currentTimeMillis / 1000,
+                (int) currentTimeMillis / 1000,
+                Integer.MAX_VALUE,
+                storageDescriptor,
+                Collections.emptyList(),
+                new HashMap<>(),
+                null,
+                null,
+                ICEBERG_TABLE_TYPE_VALUE);
+      }
+
+      Map<String, String> parameters = tbl.getParameters();
+      if (parameters == null) {
+        parameters = new HashMap<>();
+      }
+      parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+      parameters.put(METADATA_LOCATION_PROP, metadata.location());
+      if (currentMetadataLocation() != null && !currentMetadataLocation().isEmpty()) {
+        parameters.put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation());
+      }
+
+      // unnecessary but setting in case table.getParameters() starts returning a deep copy.
+      tbl.setParameters(parameters);
+      if (base != null) {
+        metaStoreClient.alter_table(database, table, tbl);
+      } else {
+        metaStoreClient.createTable(tbl);
+      }
+      threw = false;
+    } catch (TException | UnknownHostException e) {
+      throw new RuntimeException(e);
+    } finally {
+      if (threw) {
+        // if anything went wrong, clean up the uncommitted metadata file
+        deleteFile(newMetadataLocation);
+      }
+      unlock(lockId);
+    }
+
+    refresh();
+  }
+
+  private StorageDescriptor getStorageDescriptor(Schema schema) {
+    final StorageDescriptor storageDescriptor = new StorageDescriptor();
+    storageDescriptor.setCols(getColumns(schema));
+    storageDescriptor.setLocation(hiveTableLocation());
+    storageDescriptor.setOutputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat");
+    storageDescriptor.setInputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+    SerDeInfo serDeInfo = new SerDeInfo();
+    serDeInfo.setSerdeType(SerdeType.HIVE);
+    serDeInfo.setSerializationLib("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe");
+    return storageDescriptor;
+  }
+
+  private final List<FieldSchema> getColumns(Schema schema) {
+    return schema.columns().stream().map(col -> new FieldSchema(col.name(), convert(col.type()), "")).collect(Collectors.toList());
+  }
+
+  private Optional<Long> acquireLock() throws UnknownHostException, TException {
+    final LockComponent lockComponent = new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, database);
+    lockComponent.setTablename(this.table);
+    final LockRequest lockRequest = new LockRequest(Lists.newArrayList(lockComponent), System.getProperty("user.name"), InetAddress.getLocalHost().getHostName());
+    LockResponse lockResponse = metaStoreClient.lock(lockRequest);
+    LockState state = lockResponse.getState();
+    Optional<Long> lockId = Optional.of(lockResponse.getLockid());
+    while (state.equals(LockState.WAITING)) {
+      lockResponse = metaStoreClient.checkLock(lockResponse.getLockid());
+      state = lockResponse.getState();
+    }
+
+    if (!state.equals(LockState.ACQUIRED)) {
+      throw new IllegalStateException("Could not acquire the lock on table, lock request ended in state " + state);
+    }
+    return lockId;
+  }
+
+  private void unlock(Optional<Long> lockId) {
+    if (lockId.isPresent()) {
+      try {
+        metaStoreClient.unlock(lockId.get());
+      } catch (TException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/hive/HiveTables.java
+++ b/core/src/main/java/com/netflix/iceberg/hive/HiveTables.java
@@ -15,11 +15,9 @@ import java.util.List;
 
 public class HiveTables extends BaseMetastoreTables {
   private static final Splitter DOT = Splitter.on('.').limit(2);
-  private final String catalog;
 
-  public HiveTables(Configuration conf, String catalog) {
+  public HiveTables(Configuration conf) {
     super(conf);
-    this.catalog = catalog;
   }
 
   @Override
@@ -42,7 +40,7 @@ public class HiveTables extends BaseMetastoreTables {
 
   @Override
   public BaseMetastoreTableOperations newTableOps(Configuration conf, String database, String table) {
-    return new HiveTableOperations(conf, getClient(), catalog, database, table);
+    return new HiveTableOperations(conf, getClient(), database, table);
   }
 
   private IMetaStoreClient getClient() {

--- a/core/src/main/java/com/netflix/iceberg/hive/HiveTables.java
+++ b/core/src/main/java/com/netflix/iceberg/hive/HiveTables.java
@@ -1,0 +1,55 @@
+package com.netflix.iceberg.hive;
+
+import com.google.common.base.Splitter;
+import com.netflix.iceberg.BaseMetastoreTableOperations;
+import com.netflix.iceberg.BaseMetastoreTables;
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.Table;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import java.util.List;
+
+public class HiveTables extends BaseMetastoreTables {
+  private static final Splitter DOT = Splitter.on('.').limit(2);
+  private final String catalog;
+
+  public HiveTables(Configuration conf, String catalog) {
+    super(conf);
+    this.catalog = catalog;
+  }
+
+  @Override
+  public Table create(Schema schema, PartitionSpec spec, String tableIdentifier) {
+    List<String> parts = DOT.splitToList(tableIdentifier);
+    if (parts.size() == 2) {
+      return create(schema, spec, parts.get(0), parts.get(1));
+    }
+    throw new UnsupportedOperationException("Could not parse table identifier: " + tableIdentifier);
+  }
+
+  @Override
+  public Table load(String tableIdentifier) {
+    List<String> parts = DOT.splitToList(tableIdentifier);
+    if (parts.size() == 2) {
+      return load(parts.get(0), parts.get(1));
+    }
+    throw new UnsupportedOperationException("Could not parse table identifier: " + tableIdentifier);
+  }
+
+  @Override
+  public BaseMetastoreTableOperations newTableOps(Configuration conf, String database, String table) {
+    return new HiveTableOperations(conf, getClient(), catalog, database, table);
+  }
+
+  private IMetaStoreClient getClient() {
+    try {
+      return new HiveMetaStoreClient(conf);
+    } catch (MetaException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/hive/HiveTypeConverter.java
+++ b/core/src/main/java/com/netflix/iceberg/hive/HiveTypeConverter.java
@@ -1,0 +1,75 @@
+package com.netflix.iceberg.hive;
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.netflix.iceberg.types.Type;
+import com.netflix.iceberg.types.Types;
+
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+
+public final class HiveTypeConverter {
+
+  private HiveTypeConverter() {
+
+  }
+
+  public static String convert(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return "boolean";
+      case INTEGER:
+        return "int";
+      case LONG:
+        return "bigint";
+      case FLOAT:
+        return "float";
+      case DOUBLE:
+        return "double";
+      case DATE:
+        return "date";
+      case TIME:
+        throw new UnsupportedOperationException("Hive does not support time fields");
+      case TIMESTAMP:
+        return "timestamp";
+      case STRING:
+      case UUID:
+        return "string";
+      case FIXED:
+        return "binary";
+      case BINARY:
+        return "binary";
+      case DECIMAL:
+        final Types.DecimalType decimalType = (Types.DecimalType) type;
+        return format("decimal(%s,%s)", decimalType.precision(), decimalType.scale()); //TODO may be just decimal?
+      case STRUCT:
+        final Types.StructType structType = type.asStructType();
+        final String nameToType = structType.fields().stream().map(
+                f -> format("%s:%s", f.name(), convert(f.type()))
+        ).collect(Collectors.joining(","));
+        return format("struct<%s>", nameToType);
+      case LIST:
+        final Types.ListType listType = type.asListType();
+        return format("array<%s>", convert(listType.elementType()));
+      case MAP:
+        final Types.MapType mapType = type.asMapType();
+        return format("map<%s,%s>", convert(mapType.keyType()), convert(mapType.valueType()));
+      default:
+        throw new UnsupportedOperationException(type +" is not supported");
+    }
+  }
+}

--- a/core/src/test/java/com/netflix/iceberg/Test.java
+++ b/core/src/test/java/com/netflix/iceberg/Test.java
@@ -1,0 +1,23 @@
+package com.netflix.iceberg.metastore;
+
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.types.Types;
+import org.apache.hadoop.conf.Configuration;
+
+import static com.netflix.iceberg.types.Types.NestedField.required;
+
+/**
+ * Created by parth on 8/15/18.
+ */
+public class Test {
+
+  public static void main(String[] args) {
+    final Configuration configuration = new Configuration();
+    configuration.set("metastore.thrift.uris", "thrift://localhost:9083");
+    configuration.set("hive.metastore.warehouse.dir", "s3n://netflix-dataoven-prod-users/hive/warehouse");
+    final HiveTables tables = new HiveTables(configuration, "prodhive");
+    Schema schema = new Schema(Types.StructType.of(
+            required(100, "id", Types.LongType.get())).fields());
+    tables.create(schema, "pbrahmbhatt", "hivetabletest");
+  }
+}

--- a/core/src/test/java/com/netflix/iceberg/TestHiveTables.java
+++ b/core/src/test/java/com/netflix/iceberg/TestHiveTables.java
@@ -1,0 +1,24 @@
+package com.netflix.iceberg;
+
+import com.netflix.iceberg.metastore.HiveTables;
+import com.netflix.iceberg.types.Types;
+import org.apache.hadoop.conf.Configuration;
+
+import static com.netflix.iceberg.types.Types.NestedField.required;
+
+/**
+ * Created by parth on 8/15/18.
+ */
+public class TestHiveTables
+{
+
+  public static void main(String[] args) {
+    final Configuration configuration = new Configuration();
+    configuration.set("metastore.thrift.uris", "thrift://metacat.dynprod.netflix.net:12001");
+    configuration.set("hive.metastore.warehouse.dir", "s3n://netflix-dataoven-prod-users/hive/warehouse");
+    final HiveTables tables = new HiveTables(configuration, "prodhive");
+    Schema schema = new Schema(Types.StructType.of(
+            required(100, "id", Types.LongType.get())).fields());
+    tables.create(schema, "pbrahmbhatt", "hivetable");
+  }
+}


### PR DESCRIPTION
This PR includes @Parth-Brahmbhatt's changes to add a TableOperations implementation that is backed by the Hive metastore.

I'm moving this from master to a PR because the tests were not passing and Hive should be in a separate module, not core.