### PR TITLE
Use nebula publishing and git version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 allprojects {
   group = "com.netflix.iceberg"
   version = gitVersion()
-  apply plugin: 'idea'
 }
 
 apply plugin: 'nebula-aggregate-javadocs'

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ subprojects {
 
   repositories {
     mavenCentral()
-    mavenLocal()
     maven { url "http://palantir.bintray.com/releases" }
+    mavenLocal()
   }
 
   configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,13 @@ buildscript {
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.0'
     classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+'
+    classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.5'
   }
 }
 
 plugins {
   id 'nebula.netflixoss' version '4.1.0'
+  id 'com.palantir.git-version' version '0.9.1'
 }
 
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
@@ -32,7 +34,8 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 
 allprojects {
   group = "com.netflix.iceberg"
-  version = '0.3.1'
+  version = gitVersion()
+  apply plugin: 'idea'
 }
 
 apply plugin: 'nebula-aggregate-javadocs'
@@ -42,10 +45,12 @@ subprojects {
   apply plugin: 'nebula.source-jar'
   apply plugin: 'java'
   apply plugin: 'maven' // make pom files for deployment
+  apply plugin: 'nebula.maven-base-publish'
 
   repositories {
     mavenCentral()
     mavenLocal()
+    maven { url "http://palantir.bintray.com/releases" }
   }
 
   configurations {
@@ -81,6 +86,13 @@ subprojects {
     testCompile 'junit:junit:4.12'
     testCompile 'org.slf4j:slf4j-simple:1.7.5'
     testCompile 'org.mockito:mockito-all:1.10.19'
+  }
+  publishing {
+    publications {
+      nebula(MavenPublication) {
+        from components.java
+      }
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ subprojects {
 
   repositories {
     mavenCentral()
-    maven { url "http://palantir.bintray.com/releases" }
     mavenLocal()
   }
 


### PR DESCRIPTION
Uses the Nebula publishing plugin to allow `./gradlew publishToMavenLocal`. Can also consider using the nebula publishing plugin to push to the remote repository in CI as well.

Use the git version plugin to version the project based on the git version. Allows publishing snapshots upon merging PRs and removes the need to manage the release number in build.gradle manually. A new release should just be a new git tag.

Closes #65.