### PR TITLE
initial implementation of startsWith

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Evaluator.java
@@ -110,6 +110,11 @@ public class Evaluator implements Serializable {
     }
 
     @Override
+    public Boolean startsWith(BoundReference<String> ref, Literal<String> lit) {
+      return ref.get(struct).startsWith(lit.value());
+    }
+
+    @Override
     public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
       return cmp.compare(ref.get(struct), lit.value()) >= 0;

--- a/api/src/main/java/com/netflix/iceberg/expressions/Expression.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Expression.java
@@ -37,7 +37,8 @@ public interface Expression extends Serializable {
     NOT_IN,
     NOT,
     AND,
-    OR;
+    OR,
+    STARTS_WITH;
 
     /**
      * @return the operation used when this is negated

--- a/api/src/main/java/com/netflix/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/ExpressionVisitors.java
@@ -91,6 +91,10 @@ public class ExpressionVisitors {
       return null;
     }
 
+    public R startsWith(BoundReference<String> ref, Literal<String> lit) {
+      return null;
+    }
+
     public <T> R predicate(BoundPredicate<T> pred) {
       switch (pred.op()) {
         case IS_NULL:
@@ -113,6 +117,11 @@ public class ExpressionVisitors {
           return in(pred.ref(), pred.literal());
         case NOT_IN:
           return notIn(pred.ref(), pred.literal());
+        case STARTS_WITH:
+//          due to the fact that startWith function in Expressions accepts only string types casting is a must here.
+//          in  Unbound#bind function we added a check for that
+
+          return startsWith((BoundReference<String>) pred.ref(), pred.literal().to(pred.ref().type()));
         default:
           throw new UnsupportedOperationException(
               "Unknown operation for predicate: " + pred.op());

--- a/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
@@ -96,6 +96,10 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_EQ, ref(name), value);
   }
 
+  public static <T> UnboundPredicate<T> startWith(String name, T value) {
+    return new UnboundPredicate<>(Operation.STARTS_WITH, ref(name), value);
+  }
+
   public static <T> UnboundPredicate<T> predicate(Operation op, String name, T value) {
     Preconditions.checkArgument(op != Operation.IS_NULL && op != Operation.NOT_NULL,
         "Cannot create %s predicate inclusive a value", op);

--- a/api/src/main/java/com/netflix/iceberg/expressions/Predicate.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Predicate.java
@@ -59,6 +59,8 @@ public abstract class Predicate<T, R extends Reference> implements Expression {
         return String.valueOf(ref()) + " == " + literal();
       case NOT_EQ:
         return String.valueOf(ref()) + " != " + literal();
+      case STARTS_WITH:
+        return "startsWith(" + ref() + "," + literal() + ")";
 //      case IN:
 //        break;
 //      case NOT_IN:

--- a/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
@@ -21,6 +21,7 @@ import com.netflix.iceberg.types.Types;
 
 import static com.netflix.iceberg.expressions.Expression.Operation.IS_NULL;
 import static com.netflix.iceberg.expressions.Expression.Operation.NOT_NULL;
+import static com.netflix.iceberg.expressions.Expression.Operation.STARTS_WITH;
 
 public class UnboundPredicate<T> extends Predicate<T, NamedReference> {
 
@@ -61,6 +62,10 @@ public class UnboundPredicate<T> extends Predicate<T, NamedReference> {
         default:
           throw new ValidationException("Operation must be IS_NULL or NOT_NULL");
       }
+    }
+
+    if(op() == STARTS_WITH && field.type() != Types.StringType.get()) {
+      throw new ValidationException("Operation startsWith accepts only strings");
     }
 
     Literal<T> lit = literal().to(field.type());

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestStartWithExpression.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestStartWithExpression.java
@@ -1,0 +1,4 @@
+package com.netflix.iceberg.expressions;
+
+public class TestStartWithExpression {
+}


### PR DESCRIPTION
Fixes https://github.com/Netflix/iceberg/issues/49

Initial implementation only for iceberg-api expressions

Open issues:
1. should we add implementation for spark, parquet and  avro?
1. should we use case sensitive startsWith?
1. should we support unicode characters startsWith?