### PR TITLE
(WIP) Implement external mapping of IDs

### DIFF
--- a/core/src/main/java/com/netflix/iceberg/avro/AvroNamedSchemaVisitor.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/AvroNamedSchemaVisitor.java
@@ -1,0 +1,94 @@
+package com.netflix.iceberg.avro;
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.avro.Schema;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Used to visit avro schemas, but additionally pass along the schema names
+ * @param <T> Type returned by folding over the avro schema
+ */
+public abstract class AvroNamedSchemaVisitor<T> {
+  public static <T> T visit(Schema schema, String schemaName, AvroNamedSchemaVisitor<T> visitor) {
+    switch (schema.getType()) {
+      case RECORD:
+        // check to make sure this hasn't been visited before
+        String name = schema.getFullName();
+        Preconditions.checkState(!visitor.recordLevels.contains(name),
+            "Cannot process recursive Avro record %s", name);
+
+        visitor.recordLevels.push(name);
+
+        List<Schema.Field> fields = schema.getFields();
+        List<String> names = Lists.newArrayListWithExpectedSize(fields.size());
+        List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+        for (Schema.Field field : schema.getFields()) {
+          names.add(field.name());
+          results.add(visit(field.schema(), field.name(), visitor));
+        }
+
+        visitor.recordLevels.pop();
+
+        return visitor.record(schema, names, results);
+
+      case UNION:
+        List<Schema> types = schema.getTypes();
+        List<T> options = Lists.newArrayListWithExpectedSize(types.size());
+        for (Schema type : types) {
+          options.add(visit(type, schemaName, visitor));
+        }
+        return visitor.union(schema, schemaName, options);
+
+      case ARRAY:
+        return visitor.array(schema, schemaName, visit(schema.getElementType(), schemaName, visitor));
+
+      case MAP:
+        return visitor.map(schema, schemaName, visit(schema.getValueType(), schemaName, visitor));
+
+      default:
+        return visitor.primitive(schema, schemaName);
+    }
+  }
+
+  protected LinkedList<String> recordLevels = Lists.newLinkedList();
+
+  public T record(Schema record, List<String> names, List<T> fields) {
+    return null;
+  }
+
+  public T union(Schema union, String schemaName, List<T> options) {
+    return null;
+  }
+
+  public T array(Schema array, String schemaName, T element) {
+    return null;
+  }
+
+  public T map(Schema map, String schemaName, T value) {
+    return null;
+  }
+
+  public T primitive(Schema primitive, String schemaName) {
+    return null;
+  }
+}
+

--- a/core/src/main/java/com/netflix/iceberg/avro/AvroToIcebergSchemaVisitor.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/AvroToIcebergSchemaVisitor.java
@@ -1,0 +1,160 @@
+package com.netflix.iceberg.avro;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.types.Type;
+import com.netflix.iceberg.types.Types;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class AvroToIcebergSchemaVisitor extends AvroNamedSchemaVisitor<com.netflix.iceberg.Schema> {
+
+  private org.apache.avro.Schema rootSchema;
+
+  AvroToIcebergSchemaVisitor(org.apache.avro.Schema rootSchema) {
+    this.rootSchema = rootSchema;
+    if (rootSchema.getType() == org.apache.avro.Schema.Type.RECORD) {
+      nextId = rootSchema.getFields().size();
+    }
+  }
+
+  private int nextId = 1;
+
+  private int allocateId() {
+    int current = nextId;
+    nextId += 1;
+    return current;
+  }
+
+  @Override
+  public Schema record(org.apache.avro.Schema record, List<String> names, List<Schema> fields) {
+    List<org.apache.avro.Schema.Field> avroFields = record.getFields();
+    List<Types.NestedField> nestedFields = Lists.newArrayListWithExpectedSize(avroFields.size());
+    HashMap<String, Integer> idToAlias = Maps.newHashMap();
+
+    if (rootSchema == record) {
+      this.nextId = 0;
+    }
+
+    for (int i = 0; i < fields.size(); i++) {
+      org.apache.avro.Schema.Field avroField = avroFields.get(i);
+      Schema icebergSchema = fields.get(i);
+      String fieldName = names.get(i);
+
+      Types.NestedField field;
+      if (avroField.schema().getType() == org.apache.avro.Schema.Type.RECORD) {
+        // If this is a record type, take field and put it inside a struct
+        int fieldId = allocateId();
+        field =
+            AvroSchemaUtil.isOptionSchema(avroField.schema()) ?
+                Types.NestedField.optional(fieldId, fieldName, Types.StructType.of(icebergSchema.columns())) :
+                Types.NestedField.required(fieldId, fieldName, Types.StructType.of(icebergSchema.columns()));
+        idToAlias.put(fieldName, fieldId);
+      } else if (record == rootSchema) {
+        // if we're on the root, allocate fresh ids (don't use the field ids generated in the previous iteration)
+        int fieldId = allocateId();
+        Type fieldType = AvroSchemaUtil.convert(avroField.schema());
+
+        field =
+            AvroSchemaUtil.isOptionSchema(avroField.schema()) ?
+                Types.NestedField.optional(fieldId, fieldName, fieldType) :
+                Types.NestedField.required(fieldId, fieldName, fieldType);
+
+        idToAlias.put(fieldName, fieldId);
+      } else {
+        // Otherwise, just take the ids already defined in the previous run
+        field = icebergSchema.findField(fieldName);
+        idToAlias.put(fieldName, field.fieldId());
+      }
+
+      nestedFields.add(field);
+    }
+
+    return new Schema(nestedFields, idToAlias);
+  }
+
+  @Override
+  public Schema array(org.apache.avro.Schema array, String schemaName, Schema element) {
+    org.apache.avro.Schema elementSchema = array.getElementType();
+    HashMap<String, Integer> aliasToId = Maps.newHashMap();
+
+    Type icebergType = AvroSchemaUtil.convert(elementSchema);
+
+    int fieldId = allocateId();
+
+    Types.ListType listType =
+        AvroSchemaUtil.isOptionSchema(elementSchema) ?
+            Types.ListType.ofOptional(fieldId, icebergType) :
+            Types.ListType.ofRequired(fieldId, icebergType);
+
+    Types.NestedField listField =
+        listType.isElementOptional() ?
+            Types.NestedField.optional(listType.elementId(), schemaName, listType) :
+            Types.NestedField.required(listType.elementId(), schemaName, listType);
+
+    aliasToId.put(schemaName, fieldId);
+
+    return new Schema(Lists.newArrayList(listField), aliasToId);
+  }
+
+  @Override
+  public Schema map(org.apache.avro.Schema map, String schemaName, Schema value) {
+    org.apache.avro.Schema valueSchema = map.getValueType();
+
+    int keyId = allocateId();
+    int valueId = allocateId();
+
+    Type valueIcebergSchema = AvroSchemaUtil.convert(valueSchema);
+
+    // Avro only allows for maps with String as key
+    Type keyType = Types.StringType.get();
+
+    Types.MapType mapType = AvroSchemaUtil.isOptionSchema(valueSchema) ?
+        Types.MapType.ofOptional(keyId, valueId, keyType, valueIcebergSchema) :
+        Types.MapType.ofRequired(keyId, valueId, keyType, valueIcebergSchema);
+
+    Types.NestedField mapField = AvroSchemaUtil.isOptionSchema(map) ?
+        Types.NestedField.optional(nextId, schemaName, mapType) :
+        Types.NestedField.required(nextId, schemaName, mapType);
+
+    return new Schema(mapField);
+  }
+
+  @Override
+  public Schema primitive(org.apache.avro.Schema primitive, String schemaName) {
+    if (primitive.getType() == org.apache.avro.Schema.Type.NULL) return null;
+
+    HashMap<String, Integer> aliasToId = Maps.newHashMap();
+
+    Type primitiveType = AvroSchemaUtil.convert(primitive);
+
+    int fieldId = allocateId();
+
+    Types.NestedField primitiveField =
+        AvroSchemaUtil.isOptionSchema(primitive) ?
+            Types.NestedField.optional(fieldId, schemaName, primitiveType) :
+            Types.NestedField.required(fieldId, schemaName, primitiveType);
+
+    aliasToId.put(schemaName, fieldId);
+    return new Schema(Lists.newArrayList(primitiveField), aliasToId);
+  }
+
+  @Override
+  public Schema union(org.apache.avro.Schema union, String schemaName, List<Schema> options) {
+    Preconditions.checkArgument(AvroSchemaUtil.isOptionSchema(union),
+        "Unsupported type: non-option union: {}", union);
+    // records, arrays, and maps will check nullability later
+
+    HashMap<String, Integer> aliasToId = Maps.newHashMap();
+
+    aliasToId.put(schemaName, nextId);
+
+    int fieldId = options.get(1).findField(schemaName).fieldId();
+    Type primitiveType = AvroSchemaUtil.convert(union);
+
+    return new Schema(Lists.newArrayList(Types.NestedField.optional(fieldId, schemaName, primitiveType)), aliasToId);
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/avro/AvroToIcebergSchemaVisitor.java
+++ b/core/src/main/java/com/netflix/iceberg/avro/AvroToIcebergSchemaVisitor.java
@@ -1,5 +1,21 @@
 package com.netflix.iceberg.avro;
 
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/core/src/test/java/com/netflix/iceberg/avro/TestAvroToIcebergSchemaConversions.java
+++ b/core/src/test/java/com/netflix/iceberg/avro/TestAvroToIcebergSchemaConversions.java
@@ -1,0 +1,76 @@
+package com.netflix.iceberg.avro;
+
+import com.netflix.iceberg.types.Types;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestAvroToIcebergSchemaConversions {
+  @Test
+  public void testRecordWithRequiredAndOptionalConversion() {
+    Schema schema = SchemaBuilder.record("foo")
+        .fields()
+        .requiredString("bar")
+        .optionalBoolean("baz")
+        .endRecord();
+
+    com.netflix.iceberg.Schema result =
+        AvroToIcebergSchemaVisitor.visit(schema, schema.getName(), new AvroToIcebergSchemaVisitor(schema));
+
+    Types.StructType record = result.asStruct();
+
+    Types.NestedField barField = record.field("bar");
+    Assert.assertEquals(barField.fieldId(), 0);
+    Assert.assertEquals(barField.name(), "bar");
+    Assert.assertTrue(barField.isRequired());
+
+    Types.NestedField bazField = record.field("baz");
+    Assert.assertEquals(bazField.fieldId(), 1);
+    Assert.assertEquals(bazField.name(), "baz");
+    Assert.assertTrue(bazField.isOptional());
+  }
+
+  @Test
+  public void testNestedRecordsWithRequiredAndOptionalConversion() {
+    Schema schema = SchemaBuilder.record("foo")
+        .fields()
+        .name("bar")
+        .type()
+        .record("baz")
+        .fields()
+        .optionalDouble("number")
+        .requiredLong("otherNumber")
+        .endRecord()
+        .noDefault()
+        .optionalBytes("myBytes")
+        .endRecord();
+
+    Schema endUnion = SchemaBuilder.array().items().unionOf().booleanBuilder().endBoolean().endUnion();
+
+    com.netflix.iceberg.Schema icebergSchema = AvroNamedSchemaVisitor.visit(schema, schema.getName(), new AvroToIcebergSchemaVisitor(schema));
+    Types.StructType icebergStruct = icebergSchema.asStruct();
+
+    Types.NestedField myBytes = icebergStruct.field("myBytes");
+    Assert.assertEquals(myBytes.fieldId(), 3);
+  }
+
+  @Test
+  public void fooTest() {
+    Schema schema = SchemaBuilder.record("foo")
+        .fields()
+        .name("bar")
+        .type()
+        .record("baz")
+        .fields()
+        .optionalDouble("number")
+        .requiredLong("otherNumber")
+        .endRecord()
+        .noDefault()
+        .optionalBytes("myBytes")
+        .endRecord();
+
+    com.netflix.iceberg.Schema schema1 = new com.netflix.iceberg.Schema(AvroSchemaUtil.convert(schema).asStructType().fields());
+    System.out.println(schema1);
+  }
+}

--- a/core/src/test/java/com/netflix/iceberg/avro/TestAvroToIcebergSchemaConversions.java
+++ b/core/src/test/java/com/netflix/iceberg/avro/TestAvroToIcebergSchemaConversions.java
@@ -46,31 +46,10 @@ public class TestAvroToIcebergSchemaConversions {
         .optionalBytes("myBytes")
         .endRecord();
 
-    Schema endUnion = SchemaBuilder.array().items().unionOf().booleanBuilder().endBoolean().endUnion();
-
     com.netflix.iceberg.Schema icebergSchema = AvroNamedSchemaVisitor.visit(schema, schema.getName(), new AvroToIcebergSchemaVisitor(schema));
     Types.StructType icebergStruct = icebergSchema.asStruct();
 
     Types.NestedField myBytes = icebergStruct.field("myBytes");
-    Assert.assertEquals(myBytes.fieldId(), 3);
-  }
-
-  @Test
-  public void fooTest() {
-    Schema schema = SchemaBuilder.record("foo")
-        .fields()
-        .name("bar")
-        .type()
-        .record("baz")
-        .fields()
-        .optionalDouble("number")
-        .requiredLong("otherNumber")
-        .endRecord()
-        .noDefault()
-        .optionalBytes("myBytes")
-        .endRecord();
-
-    com.netflix.iceberg.Schema schema1 = new com.netflix.iceberg.Schema(AvroSchemaUtil.convert(schema).asStructType().fields());
-    System.out.println(schema1);
+    Assert.assertEquals(myBytes.fieldId(), 1);
   }
 }

--- a/core/src/test/java/com/netflix/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/com/netflix/iceberg/avro/TestReadProjection.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("Duplicates")
 public abstract class TestReadProjection {
   protected abstract Record writeAndRead(String desc,
                                          Schema writeSchema,


### PR DESCRIPTION
Initial fix for https://github.com/Netflix/iceberg/issues/71

This implementation introduces `AvroNamedSchemaVisitor<T>` and the `AvroToIcebergSchemaVisitor<iceberg.Schema>` types in order to overcome the fact that `AvroSchemaVisitor` only passes the schema at the field level, neglecting to pass in the field names which are needed generate the schema.

There are a few "workarounds" in the implementation of the `record` method which I don't really like, still need to iterate on that.

There are still open issues which need to be resolved:

1. Add Parquet visitor with the same logic of sequential IDs
1. The field ids mappings start with `0`, and they also map structs in a table with ids (is this desired?)
1. Field id mappings assign ids to the top level fields first, and then iterate complex type
1. There is still a gap regarding the table properties update, which seems essential in the open issue, but I still don't have the full mental picture to implement it
1. More tests need to be created for all types of Avro schemas (currently only `Record` is tested, need to add tests for `Map`, `Union`, `Array`, etc..)
1. Need to make sure the logic for assigning ids holds for all these types