### PR TITLE
Remove Closeable from TableScan interface.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/TableScan.java
+++ b/api/src/main/java/com/netflix/iceberg/TableScan.java
@@ -18,6 +18,7 @@ package com.netflix.iceberg;
 
 import com.google.common.collect.Lists;
 import com.netflix.iceberg.expressions.Expression;
+import com.netflix.iceberg.io.CloseableIterable;
 import java.io.Closeable;
 import java.util.Collection;
 
@@ -27,7 +28,7 @@ import java.util.Collection;
  * TableScan objects are immutable and can be shared between threads. Refinement methods, like
  * {@link #select(Collection)} and {@link #filter(Expression)}, create new TableScan instances.
  */
-public interface TableScan extends Closeable {
+public interface TableScan {
   /**
    * Returns the {@link Table} from which this scan loads data.
    *
@@ -92,7 +93,7 @@ public interface TableScan extends Closeable {
    *
    * @return an Iterable of file tasks that are required by this scan
    */
-  Iterable<FileScanTask> planFiles();
+  CloseableIterable<FileScanTask> planFiles();
 
   /**
    * Plan the {@link CombinedScanTask tasks} for this scan.
@@ -101,7 +102,7 @@ public interface TableScan extends Closeable {
    *
    * @return an Iterable of tasks for this scan
    */
-  Iterable<CombinedScanTask> planTasks();
+  CloseableIterable<CombinedScanTask> planTasks();
 
   /**
    * Returns this scan's filter {@link Expression}.

--- a/api/src/main/java/com/netflix/iceberg/io/CloseableGroup.java
+++ b/api/src/main/java/com/netflix/iceberg/io/CloseableGroup.java
@@ -19,6 +19,7 @@ package com.netflix.iceberg.io;
 import com.google.common.collect.Lists;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.LinkedList;
 
 public abstract class CloseableGroup implements Closeable {
@@ -35,6 +36,22 @@ public abstract class CloseableGroup implements Closeable {
       if (toClose != null) {
         toClose.close();
       }
+    }
+  }
+
+  static class ClosingIterable<T> extends CloseableGroup implements CloseableIterable<T> {
+    private final Iterable<T> iterable;
+
+    public ClosingIterable(Iterable<T> iterable, Iterable<Closeable> closeables) {
+      this.iterable = iterable;
+      for (Closeable closeable : closeables) {
+        addCloseable(closeable);
+      }
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+      return iterable.iterator();
     }
   }
 }

--- a/data/src/main/java/com/netflix/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/com/netflix/iceberg/data/TableScanIterable.java
@@ -61,7 +61,7 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
   private final TableOperations ops;
   private final Schema projection;
   private final boolean reuseContainers;
-  private final Iterable<CombinedScanTask> tasks;
+  private final CloseableIterable<CombinedScanTask> tasks;
 
   TableScanIterable(TableScan scan, List<String> columns, boolean reuseContainers) {
     Preconditions.checkArgument(scan.table() instanceof HasTableOperations,
@@ -120,6 +120,12 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
         throw new UnsupportedOperationException(String.format("Cannot read %s file: %s",
             task.file().format().name(), task.file().path()));
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    tasks.close(); // close manifests from scan planning
+    super.close(); // close data files
   }
 
   private class ScanIterator implements Iterator<Record>, Closeable {

--- a/pig/src/main/java/com/netflix/iceberg/pig/IcebergPigInputFormat.java
+++ b/pig/src/main/java/com/netflix/iceberg/pig/IcebergPigInputFormat.java
@@ -98,7 +98,9 @@ public class IcebergPigInputFormat<T> extends InputFormat<Void, T> {
     }
 
     //Wrap in Splits
-    scan.planTasks().forEach((scanTask) -> splits.add(new IcebergSplit(scanTask)));
+    try (CloseableIterable<CombinedScanTask> tasks = scan.planTasks()) {
+      tasks.forEach((scanTask) -> splits.add(new IcebergSplit(scanTask)));
+    }
 
     return splits;
   }

--- a/spark/src/main/java/com/netflix/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/source/Reader.java
@@ -218,16 +218,10 @@ class Reader implements DataSourceReader, SupportsScanUnsafeRow, SupportsPushDow
         }
       }
 
-      boolean threw = true;
-      try {
-        this.tasks = Lists.newArrayList(scan.planTasks());
-        threw = false;
-      } finally {
-        try {
-          Closeables.close(scan, threw);
-        } catch (IOException e) {
-          throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
-        }
+      try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
+        this.tasks = Lists.newArrayList(tasksIterable);
+      }  catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
       }
     }
 


### PR DESCRIPTION
TableScan should be immutable so it can be shared between threads. If
TableScan is Closeable, then it can't be shared because resources in use
from one thread can be closed by another when the scan is closed.

Instead, the iterables created by a scan should be closeable.