### PR TITLE
Support customizing the location where data is written in Spark.

### DIFF
--- a/core/src/main/java/com/netflix/iceberg/TableProperties.java
+++ b/core/src/main/java/com/netflix/iceberg/TableProperties.java
@@ -63,4 +63,8 @@ public class TableProperties {
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 
   public static final String OBJECT_STORE_PATH = "write.object-storage.path";
+
+  // This only applies to files written after this property is set. Files previously written aren't relocated to
+  // reflect this parameter.
+  public static final String WRITE_NEW_DATA_LOCATION = "write.data.location";
 }

--- a/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
@@ -20,10 +20,13 @@ import com.google.common.base.Preconditions;
 import com.netflix.iceberg.FileFormat;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.Table;
+import com.netflix.iceberg.TableProperties;
 import com.netflix.iceberg.hadoop.HadoopTables;
 import com.netflix.iceberg.spark.SparkSchemaUtil;
 import com.netflix.iceberg.types.CheckCompatibility;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.sources.DataSourceRegister;
@@ -86,7 +89,11 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
           .toUpperCase(Locale.ENGLISH));
     }
 
-    return Optional.of(new Writer(table, lazyConf(), format));
+    String dataLocation = options.get(TableProperties.WRITE_NEW_DATA_LOCATION)
+        .orElse(table.properties().getOrDefault(
+            TableProperties.WRITE_NEW_DATA_LOCATION,
+            new Path(new Path(table.location()), "data").toString()));
+    return Optional.of(new Writer(table, lazyConf(), format, dataLocation));
   }
 
   protected Table findTable(DataSourceOptions options) {

--- a/spark/src/main/java/com/netflix/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/source/Writer.java
@@ -91,16 +91,18 @@ class Writer implements DataSourceWriter, SupportsWriteInternalRow {
   private final Table table;
   private final Configuration conf;
   private final FileFormat format;
+  private final String dataLocation;
 
-  Writer(Table table, Configuration conf, FileFormat format) {
+  Writer(Table table, Configuration conf, FileFormat format, String dataLocation) {
     this.table = table;
     this.conf = conf;
     this.format = format;
+    this.dataLocation = dataLocation;
   }
 
   @Override
   public DataWriterFactory<InternalRow> createInternalRowWriterFactory() {
-    return new WriterFactory(table.spec(), format, dataLocation(), table.properties(), conf);
+    return new WriterFactory(table.spec(), format, dataLocation, table.properties(), conf);
   }
 
   @Override
@@ -164,16 +166,11 @@ class Writer implements DataSourceWriter, SupportsWriteInternalRow {
     return defaultValue;
   }
 
-  private String dataLocation() {
-    return new Path(new Path(table.location()), "data").toString();
-  }
-
   @Override
   public String toString() {
     return String.format("IcebergWrite(table=%s, type=%s, format=%s)",
         table, table.schema().asStruct(), format);
   }
-
 
   private static class TaskCommit implements WriterCommitMessage {
     private final DataFile[] files;

--- a/spark/src/test/java/com/netflix/iceberg/spark/source/TestParquetWrite.java
+++ b/spark/src/test/java/com/netflix/iceberg/spark/source/TestParquetWrite.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.netflix.iceberg.PartitionSpec;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.Table;
+import com.netflix.iceberg.TableProperties;
 import com.netflix.iceberg.hadoop.HadoopTables;
 import com.netflix.iceberg.types.Types;
 import org.apache.hadoop.conf.Configuration;
@@ -68,7 +69,9 @@ public class TestParquetWrite {
   public void testBasicWrite() throws IOException {
     File parent = temp.newFolder("parquet");
     File location = new File(parent, "test");
+    File dataLocation = new File(parent, "test-data");
     location.mkdirs();
+    dataLocation.mkdirs();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -85,6 +88,7 @@ public class TestParquetWrite {
     // TODO: incoming columns must be ordered according to the table's schema
     df.select("id", "data").write()
         .format("iceberg")
+        .option(TableProperties.WRITE_NEW_DATA_LOCATION, "file://" + dataLocation.getAbsolutePath())
         .mode("append")
         .save(location.toString());
 


### PR DESCRIPTION
Closes https://github.com/Netflix/iceberg/issues/93.

Note that we only use this in the Spark writer, but this also has to be worked into the other integrations.